### PR TITLE
Add installation instructions with conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ They will be installed in the installation step!
 
 ## :floppy_disk: Installation
 
+The installation can be done either using the Python provided by apt (on Linux) or via conda (on Linux and macOS).
+
+### Installation with apt
+
 Install `python3`, if not installed (in **Ubuntu 20.04**):
 
 ```bash
@@ -55,6 +59,24 @@ pip install virtualenv
 python3 -m venv your_virtual_env
 source your_virtual_env/bin/activate
 ```
+
+## Installation with conda
+
+Install in a conda environment the required dependencies:
+
+```bash
+mamba create -n adamenv -c conda-forge -c robostack jax casadi pytorch numpy lxml prettytable matplotlib ros-noetic-urdfdom-py
+```
+
+Activate the environment, clone the repo and install the library:
+
+```bash
+mamba activate adamenv
+git clone https://github.com/dic-iit/ADAM.git
+cd ADAM
+pip install .
+```
+
 
 ## :rocket: Usage
 


### PR DESCRIPTION
As in the [IIT's AMI lab](https://ami.iit.it/) use conda/mamba to provide binaries for the libraries contained in the robotology-superbuild (see https://github.com/robotology/robotology-superbuild/blob/master/doc/conda-forge.md), it is convenient to have instruction on how to install adam in a conda environment so that people that use ADAM in Linux or macOS along with robotology libraries. I tested these instructions successfully on conda in Ubuntu 20.04 .


