### PR TITLE
Fix numpy typing dep

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,18 +4,33 @@ description = Automatic Differentiation for rigid body AlgorithMs
 author = "Giuseppe L'Erario"
 author_email = gl.giuseppelerario@gmail.com
 license_file = LICENSE
+url = https://github.com/ami-iit/ADAM
+
+keywords =
+    robotics
+    urdf
+    rigid body dynamics
+    featherstone
+    automatic-differentiation
+    optimization
+    casadi
+    jax
+    pytorch
+    reinforcement-learning
+    motion-planning
 
 [options]
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
-        numpy
+        jax
+        jaxlib
+        numpy >=1.20
         scipy
         casadi
         matplotlib
         prettytable
         urdf_parser_py
-        jax[cpu]
         torch
 
 [options.extras_require]

--- a/tests/test_Jax_computations.py
+++ b/tests/test_Jax_computations.py
@@ -193,7 +193,5 @@ def test_gravity_term():
     G_iDyn_np = np.concatenate(
         (G_iDyn.baseWrench().toNumPy(), G_iDyn.jointTorques().toNumPy())
     )
-    print(G_iDyn_np)
     G_test = comp.gravity_term(H_b, s_)
-    print(G_test)
     assert G_iDyn_np - G_test == pytest.approx(0.0, abs=1e-4)

--- a/tests/test_NumPy_computations.py
+++ b/tests/test_NumPy_computations.py
@@ -192,7 +192,5 @@ def test_gravity_term():
     G_iDyn_np = np.concatenate(
         (G_iDyn.baseWrench().toNumPy(), G_iDyn.jointTorques().toNumPy())
     )
-    print(G_iDyn_np)
     G_test = comp.gravity_term(H_b, s_)
-    print(G_test)
     assert G_iDyn_np - G_test == pytest.approx(0.0, abs=1e-4)


### PR DESCRIPTION
I've bumped the NumPy version to 1.20 since [NumPy Typing](https://numpy.org/devdocs/reference/typing.html) requires NumPy >= 1.20. 

I'm using this PR also to extend a bit the `setup.cfg` and to remove 2 useless prints spotted in the tests.

Fixes #7 