### PR TITLE
Specify --no-deps in pip install via conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Activate the environment, clone the repo and install the library:
 mamba activate adamenv
 git clone https://github.com/dic-iit/ADAM.git
 cd ADAM
-pip install .
+pip install --no-deps .
 ```
 
 ## :rocket: Usage


### PR DESCRIPTION
If we do not pass this command for the conda packages that do not install correctly the pip metadata, the `pip install .`  command will install again the packages from `PyPI`. 
For example, this will happen for casadi until https://github.com/conda-forge/casadi-feedstock/pull/59 is merged.