### PR TITLE
Split deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ They will be installed in the installation step!
 
 ## :floppy_disk: Installation
 
+### Installation with pip
+
 The installation can be done either using the Python provided by apt (on Linux) or via conda (on Linux and macOS).
 
 Install `python3`, if not installed (in **Ubuntu 20.04**):

--- a/README.md
+++ b/README.md
@@ -43,23 +43,13 @@ They will be installed in the installation step!
 
 The installation can be done either using the Python provided by apt (on Linux) or via conda (on Linux and macOS).
 
-### Installation with apt
-
 Install `python3`, if not installed (in **Ubuntu 20.04**):
 
 ```bash
 sudo apt install python3.8
 ```
 
-Clone the repo and install the library:
-
-```bash
-git clone https://github.com/dic-iit/ADAM.git
-cd ADAM
-pip install .
-```
-
-preferably in a [virtual environment](https://docs.python.org/3/library/venv.html#venv-def). For example:
+Create a [virtual environment](https://docs.python.org/3/library/venv.html#venv-def), if you prefer. For example:
 
 ```bash
 pip install virtualenv
@@ -67,13 +57,64 @@ python3 -m venv your_virtual_env
 source your_virtual_env/bin/activate
 ```
 
+Clone the repo:
+
+```bash
+git clone https://github.com/dic-iit/ADAM.git
+cd ADAM
+```
+
+- Install **Jax** interface:
+
+  ```bash
+  pip install .[jax]
+  ```
+
+- Install **CasAdi** interface:
+
+  ```bash
+  pip install .[casadi]
+  ```
+
+- Install **PyTorch** interface:
+
+  ```bash
+  pip install .[pytorch]
+  ```
+
+- Install **ALL** the interfaces:
+
+  ```bash
+  pip install .[all]
+  ```
+
 ## Installation with conda
 
 Install in a conda environment the required dependencies:
 
-```bash
-mamba create -n adamenv -c conda-forge -c robostack jax casadi pytorch numpy lxml prettytable matplotlib ros-noetic-urdfdom-py
-```
+- **Jax** interface dependencies:
+
+  ```bash
+  mamba create -n adamenv -c conda-forge -c robostack casadi numpy lxml prettytable matplotlib ros-noetic-urdfdom-py
+  ```
+
+- **CasAdi** interface dependencies:
+
+  ```bash
+  mamba create -n adamenv -c conda-forge -c robostack jax numpy lxml prettytable matplotlib ros-noetic-urdfdom-py
+  ```
+
+- **PyTorch** interface dependencies:
+
+  ```bash
+  mamba create -n adamenv -c conda-forge -c robostack pytorch numpy lxml prettytable matplotlib ros-noetic-urdfdom-py
+  ```
+
+- **ALL** interface dependencies:
+
+  ```bash
+  mamba create -n adamenv -c conda-forge -c robostack jax casadi pytorch numpy lxml prettytable matplotlib ros-noetic-urdfdom-py
+  ```
 
 Activate the environment, clone the repo and install the library:
 
@@ -89,10 +130,10 @@ pip install --no-deps .
 The following are small snippets of the use of ADAM. More examples are arriving!
 Have also a look at te `tests` folder.
 
-### Jax
+### Jax interface
 
 ```python
-from adam.jax.computations import KinDynComputations
+from adam.jax import KinDynComputations
 import gym_ignition_models
 import numpy as np
 
@@ -115,10 +156,10 @@ M = kinDyn.mass_matrix(w_H_b, joints)
 print(M)
 ```
 
-### CasADi
+### CasADi interface
 
 ```python
-from adam.casadi.computations import KinDynComputations
+from adam.casadi import KinDynComputations
 import gym_ignition_models
 import numpy as np
 
@@ -141,10 +182,10 @@ M = kinDyn.mass_matrix_fun()
 print(M(w_H_b, joints))
 ```
 
-### PyTorch
+### PyTorch interface
 
 ```python
-from adam.pytorch.computations import KinDynComputations
+from adam.pytorch import KinDynComputations
 import gym_ignition_models
 import numpy as np
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ They will be installed in the installation step!
 
 ## :floppy_disk: Installation
 
-### Installation with pip
-
 The installation can be done either using the Python provided by apt (on Linux) or via conda (on Linux and macOS).
+
+### Installation with pip
 
 Install `python3`, if not installed (in **Ubuntu 20.04**):
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ cd ADAM
   pip install .[all]
   ```
 
+If you don't want to clone the repo you can install ADAM with:
+
+```bash
+pip install adam[selected-interface]@git+https://github.com/ami-iit/ADAM
+```
+
 ## Installation with conda
 
 Install in a conda environment the required dependencies:

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,24 @@ package_dir =
         = src
 python_requires = >=3.8
 install_requires =
+        numpy >=1.20
+        scipy
+        casadi
+        prettytable
+        urdf_parser_py
+
+[options.packages.find]
+where = src
+
+[options.extras_require]
+jax =
+        jax
+        jaxlib
+casadi =
+        casadi
+pytorch =
+        torch
+test =
         jax
         jaxlib
         numpy >=1.20
@@ -35,16 +53,20 @@ install_requires =
         prettytable
         urdf_parser_py
         torch
-
-[options.packages.find]
-where = src
-
-[options.extras_require]
-test =
         pytest
         idyntree
         gym-ignition-models
         black
+all =
+        jax
+        jaxlib
+        numpy >=1.20
+        scipy
+        casadi
+        matplotlib
+        prettytable
+        urdf_parser_py
+        torch
 
 [tool:pytest]
 addopts = --capture=no --verbose

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,12 +46,7 @@ pytorch =
 test =
         jax
         jaxlib
-        numpy >=1.20
-        scipy
         casadi
-        matplotlib
-        prettytable
-        urdf_parser_py
         torch
         pytest
         idyntree
@@ -60,12 +55,7 @@ test =
 all =
         jax
         jaxlib
-        numpy >=1.20
-        scipy
         casadi
-        matplotlib
-        prettytable
-        urdf_parser_py
         torch
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ author = "Giuseppe L'Erario"
 author_email = gl.giuseppelerario@gmail.com
 license_file = LICENSE
 url = https://github.com/ami-iit/ADAM
-version = 0.0.1
+version = 0.0.2
 
 keywords =
     robotics

--- a/src/adam/__init__.py
+++ b/src/adam/__init__.py
@@ -1,5 +1,3 @@
 # Copyright (C) 2021 Istituto Italiano di Tecnologia (IIT). All rights reserved.
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
-
-from . import casadi, core, geometry, jax, numpy

--- a/src/adam/casadi/__init__.py
+++ b/src/adam/casadi/__init__.py
@@ -2,4 +2,4 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-from .computations import KinDynComputation
+from .computations import KinDynComputations

--- a/src/adam/casadi/__init__.py
+++ b/src/adam/casadi/__init__.py
@@ -2,4 +2,4 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-from . import computations
+from .computations import KinDynComputation

--- a/src/adam/jax/__init__.py
+++ b/src/adam/jax/__init__.py
@@ -2,4 +2,4 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-from . import computations
+from .computations import KinDynComputations

--- a/src/adam/numpy/__init__.py
+++ b/src/adam/numpy/__init__.py
@@ -2,4 +2,4 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-from . import computations
+from .computations import KinDynComputations

--- a/src/adam/pytorch/__init__.py
+++ b/src/adam/pytorch/__init__.py
@@ -2,4 +2,4 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-from . import computations
+from .computations import KinDynComputations

--- a/tests/test_CasADi_computations.py
+++ b/tests/test_CasADi_computations.py
@@ -10,7 +10,7 @@ import idyntree.swig as idyntree
 import numpy as np
 import pytest
 
-from adam.casadi.computations import KinDynComputations
+from adam.casadi import KinDynComputations
 from adam.geometry import utils
 
 model_path = gym_ignition_models.get_model_file("iCubGazeboV2_5")

--- a/tests/test_Jax_computations.py
+++ b/tests/test_Jax_computations.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 from adam.geometry import utils
-from adam.jax.computations import KinDynComputations
+from adam.jax import KinDynComputations
 
 model_path = gym_ignition_models.get_model_file("iCubGazeboV2_5")
 

--- a/tests/test_NumPy_computations.py
+++ b/tests/test_NumPy_computations.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 from adam.geometry import utils
-from adam.numpy.computations import KinDynComputations
+from adam.numpy import KinDynComputations
 
 model_path = gym_ignition_models.get_model_file("iCubGazeboV2_5")
 

--- a/tests/test_pytorch_computations.py
+++ b/tests/test_pytorch_computations.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 
 from adam.geometry import utils
-from adam.pytorch.computations import KinDynComputations
+from adam.pytorch import KinDynComputations
 
 model_path = gym_ignition_models.get_model_file("iCubGazeboV2_5")
 


### PR DESCRIPTION
I want to update the installation procedure for pruning dependencies that the user might not need in this PR.
For example, the installation would require `PyTorch` even if the user just needs the `CasAdi` interface.

Now the installation would need:
- jax interface:

  ```bash
  pip install .[jax]
  ```
- casadi interface:

  ```bash
  pip install .[casadi]
  ```
- pytorch interface:
  ```bash
  pip install .[pytorch]
  ```

or, if the user does not want to clone the repo:

```bash
pip install adam[selected-interface]@git+https://github.com/ami-iit/ADAM
```

I took also the occasion to change the import syntax.
Before:
```python
from adam.casadi.computations import KinDynComputations
```
After:
```python
from adam.casadi import KinDynComputations
```

The import syntax used before is still working, so the old code using adam does not need to be updated.