### PR TITLE
Fix tree creation

### DIFF
--- a/src/adam/core/urdf_tree.py
+++ b/src/adam/core/urdf_tree.py
@@ -105,34 +105,40 @@ class URDFTree:
         parent_0 = Element("world_link")
         tree.parents.append(parent_0)
 
-        i = 1
-
         table_joints = PrettyTable(["Idx", "Joint name", "Type", "Parent", "Child"])
         table_joints.title = "Joints"
-        # Building the tree. Links (with inertia) are connected with joints
-        for item in self.robot_desc.joint_map:
-            # I'm assuming that the only possible active joint is revolute (not prismatic)
-            parent = self.robot_desc.joint_map[item].parent
-            child = self.robot_desc.joint_map[item].child
-            if self.robot_desc.link_map[child].name != self.root_link:
-                joints += [item]
-                table_joints.add_row(
-                    [
-                        i,
-                        item,
-                        self.robot_desc.joint_map[item].type,
-                        parent,
-                        child,
-                    ]
-                )
-                i += 1
-                tree.joints.append(self.robot_desc.joint_map[item])
-                tree.links.append(
-                    self.robot_desc.link_map[self.robot_desc.joint_map[item].child]
-                )
-                tree.parents.append(
+
+        # Cicling on the joints. I need to check that the tree order is correct.
+        # An element in the parent list should be already present in the link list. If not, no element is added to the tree.
+        # If a joint is already in the list of joints, no element is added to the tree.
+        i = 1
+        for _ in self.robot_desc.joint_map:
+            for item in self.robot_desc.joint_map:
+                parent = self.robot_desc.joint_map[item].parent
+                child = self.robot_desc.joint_map[item].child
+                if (
                     self.robot_desc.link_map[self.robot_desc.joint_map[item].parent]
-                )
+                    in tree.links
+                    and self.robot_desc.joint_map[item] not in tree.joints
+                ):
+                    joints += [item]
+                    table_joints.add_row(
+                        [
+                            i,
+                            item,
+                            self.robot_desc.joint_map[item].type,
+                            parent,
+                            child,
+                        ]
+                    )
+                    i += 1
+                    tree.joints.append(self.robot_desc.joint_map[item])
+                    tree.links.append(
+                        self.robot_desc.link_map[self.robot_desc.joint_map[item].child]
+                    )
+                    tree.parents.append(
+                        self.robot_desc.link_map[self.robot_desc.joint_map[item].parent]
+                    )
         tree.N = len(tree.links)
         logging.debug(table_joints)
         return links, frames, joints, tree

--- a/src/adam/core/urdf_tree.py
+++ b/src/adam/core/urdf_tree.py
@@ -94,7 +94,7 @@ class URDFTree:
                         self.robot_desc.parent_map[item][1],
                     ]
                 )
-            except:
+            except Exception:
                 pass
         logging.debug(table_frames)
         """The node 0 contains the 1st link, the fictitious joint that connects the root the the world
@@ -114,10 +114,7 @@ class URDFTree:
             # I'm assuming that the only possible active joint is revolute (not prismatic)
             parent = self.robot_desc.joint_map[item].parent
             child = self.robot_desc.joint_map[item].child
-            if (
-                self.robot_desc.link_map[child].inertial is not None
-                and self.robot_desc.link_map[parent].inertial is not None
-            ):
+            if self.robot_desc.link_map[child].name != self.root_link:
                 joints += [item]
                 table_joints.add_row(
                     [


### PR DESCRIPTION
This pr should fix #17.

A cycle over the joints is added to ensure that a parent link is added to the parent list only if it is already in the link list. 

This check allows the current loading of `urdf`s in which the joints order is not the one in the kinematic tree.