### PR TITLE
Avoid gym_ignition_models references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ Have also a look at te `tests` folder.
 
 ```python
 from adam.jax import KinDynComputations
-import gym_ignition_models
+import icub_models
 import numpy as np
 
-# if you want to use gym-ignition https://github.com/robotology/gym-ignition to retrieve the urdf
-model_path = gym_ignition_models.get_model_file("iCubGazeboV2_5")
+# if you want to icub-models https://github.com/robotology/icub-models to retrieve the urdf
+model_path = icub_models.get_model_file("iCubGazeboV2_5")
 # The joint list
 joints_name_list = [
     'torso_pitch', 'torso_roll', 'torso_yaw', 'l_shoulder_pitch',
@@ -171,11 +171,11 @@ print(M)
 
 ```python
 from adam.casadi import KinDynComputations
-import gym_ignition_models
+import icub_models
 import numpy as np
 
-# if you want to use gym-ignition https://github.com/robotology/gym-ignition to retrieve the urdf
-model_path = gym_ignition_models.get_model_file("iCubGazeboV2_5")
+# if you want to icub-models https://github.com/robotology/icub-models to retrieve the urdf
+model_path = icub_models.get_model_file("iCubGazeboV2_5")
 # The joint list
 joints_name_list = [
     'torso_pitch', 'torso_roll', 'torso_yaw', 'l_shoulder_pitch',
@@ -197,11 +197,11 @@ print(M(w_H_b, joints))
 
 ```python
 from adam.pytorch import KinDynComputations
-import gym_ignition_models
+import icub_models
 import numpy as np
 
-# if you want to use gym-ignition https://github.com/robotology/gym-ignition to retrieve the urdf
-model_path = gym_ignition_models.get_model_file("iCubGazeboV2_5")
+# if you want to icub-models https://github.com/robotology/icub-models to retrieve the urdf
+model_path = icub_models.get_model_file("iCubGazeboV2_5")
 # The joint list
 joints_name_list = [
     'torso_pitch', 'torso_roll', 'torso_yaw', 'l_shoulder_pitch',


### PR DESCRIPTION
`gym-ignition-models`  is just meant to be a repo to be used with `gym-ignition`. The official reference for iCub models, that contains all up-to-date existing iCub models is https://github.com/robotology/icub-models, that thanks to @GiulioRomualdi has a Python interface and is available in both conda-forge and PyPI. See https://github.com/robotology/gym-ignition-models/issues/19 for a related discussion.