### PR TITLE
Fix non-deterministic test failure in test_gravity_term 

### DIFF
--- a/tests/test_CasADi_computations.py
+++ b/tests/test_CasADi_computations.py
@@ -76,7 +76,7 @@ joints_dot_val = (np.random.rand(n_dofs) - 0.5) * 5
 
 # set iDynTree kinDyn
 H_b_idyn = H_from_Pos_RPY_idyn(xyz, rpy)
-vb = idyntree.Twist()
+vb = idyntree.Twist.Zero()
 [vb.setVal(i, base_vel[i]) for i in range(6)]
 
 s = idyntree.VectorDynSize(n_dofs)
@@ -190,7 +190,7 @@ def test_coriolis_term():
 
 
 def test_gravity_term():
-    vb0 = idyntree.Twist()
+    vb0 = idyntree.Twist.Zero()
     s_dot0 = idyntree.VectorDynSize(n_dofs)
     kinDyn.setRobotState(H_b_idyn, s, vb0, s_dot0, g)
     G_iDyn = idyntree.FreeFloatingGeneralizedTorques(kinDyn.model())

--- a/tests/test_Jax_computations.py
+++ b/tests/test_Jax_computations.py
@@ -76,7 +76,7 @@ joints_dot_val = (np.random.rand(n_dofs) - 0.5) * 5
 
 # set iDynTree kinDyn
 H_b_idyn = H_from_Pos_RPY_idyn(xyz, rpy)
-vb = idyntree.Twist()
+vb = idyntree.Twist.Zero()
 [vb.setVal(i, base_vel[i]) for i in range(6)]
 
 s = idyntree.VectorDynSize(n_dofs)
@@ -185,7 +185,7 @@ def test_gravity_term():
     kinDyn2.loadRobotModel(robot_iDyn.model())
     kinDyn2.setFloatingBase(root_link)
     kinDyn2.setFrameVelocityRepresentation(idyntree.MIXED_REPRESENTATION)
-    vb0 = idyntree.Twist()
+    vb0 = idyntree.Twist.Zero()
     s_dot0 = idyntree.VectorDynSize(n_dofs)
     kinDyn2.setRobotState(H_b_idyn, s, vb0, s_dot0, g)
     G_iDyn = idyntree.FreeFloatingGeneralizedTorques(kinDyn2.model())

--- a/tests/test_NumPy_computations.py
+++ b/tests/test_NumPy_computations.py
@@ -75,7 +75,7 @@ joints_dot_val = (np.random.rand(n_dofs) - 0.5) * 5
 
 # set iDynTree kinDyn
 H_b_idyn = H_from_Pos_RPY_idyn(xyz, rpy)
-vb = idyntree.Twist()
+vb = idyntree.Twist.Zero()
 [vb.setVal(i, base_vel[i]) for i in range(6)]
 
 s = idyntree.VectorDynSize(n_dofs)
@@ -184,7 +184,7 @@ def test_gravity_term():
     kinDyn2.loadRobotModel(robot_iDyn.model())
     kinDyn2.setFloatingBase(root_link)
     kinDyn2.setFrameVelocityRepresentation(idyntree.MIXED_REPRESENTATION)
-    vb0 = idyntree.Twist()
+    vb0 = idyntree.Twist.Zero()
     s_dot0 = idyntree.VectorDynSize(n_dofs)
     kinDyn2.setRobotState(H_b_idyn, s, vb0, s_dot0, g)
     G_iDyn = idyntree.FreeFloatingGeneralizedTorques(kinDyn2.model())

--- a/tests/test_pytorch_computations.py
+++ b/tests/test_pytorch_computations.py
@@ -76,7 +76,7 @@ joints_dot_val = (np.random.rand(n_dofs) - 0.5) * 5
 
 # set iDynTree kinDyn
 H_b_idyn = H_from_Pos_RPY_idyn(xyz, rpy)
-vb = idyntree.Twist()
+vb = idyntree.Twist.Zero()
 [vb.setVal(i, base_vel[i]) for i in range(6)]
 
 s = idyntree.VectorDynSize(n_dofs)
@@ -185,7 +185,7 @@ def test_gravity_term():
     kinDyn2.loadRobotModel(robot_iDyn.model())
     kinDyn2.setFloatingBase(root_link)
     kinDyn2.setFrameVelocityRepresentation(idyntree.MIXED_REPRESENTATION)
-    vb0 = idyntree.Twist()
+    vb0 = idyntree.Twist.Zero()
     s_dot0 = idyntree.VectorDynSize(n_dofs)
     kinDyn2.setRobotState(H_b_idyn, s, vb0, s_dot0, g)
     G_iDyn = idyntree.FreeFloatingGeneralizedTorques(kinDyn2.model())


### PR DESCRIPTION
This PR fixes the non-deterministic test failure discussed in https://github.com/conda-forge/staged-recipes/pull/21894#issuecomment-1535488061 and https://github.com/ami-iit/ADAM/pull/38 .
The source of the non-determinism was the use of non-initialized memory, as a `idyntree.bindings.Twist` object was created, but never initialized to zero. In most of the cases their actual value was zero, but sometime its value was actually something else, resulting in a test failure. See the following code snippet for an example:
~~~
>>> import idyntree
>>> a = idyntree.bindings.Twist()
>>> a.toString()
'4.64577e-310 0 6.91004e-310  6.91004e-310 0 2.07508e-322 \n'
>>> a = idyntree.bindings.Twist.Zero()
>>> a.toString()
'0 0 0  0 0 0 \n'
~~~