### PR TITLE
Set inertial origin to zero when is none in the urdf

### DIFF
--- a/src/adam/model/std_factories/std_link.py
+++ b/src/adam/model/std_factories/std_link.py
@@ -1,16 +1,8 @@
-from dataclasses import dataclass, field
-
 import numpy.typing as npt
 import urdf_parser_py.urdf
 
 from adam.core.spatial_math import SpatialMath
 from adam.model import Link
-
-
-@dataclass
-class Pose(urdf_parser_py.urdf.Pose):
-    xyz: list = field(default_factory=lambda: [0, 0, 0])
-    rpy: list = field(default_factory=lambda: [0, 0, 0])
 
 
 class StdLink(Link):
@@ -24,10 +16,9 @@ class StdLink(Link):
         self.collisions = link.collisions
 
         # if the link has inertial properties, but the origin is None, let's add it
-        if link.inertial is not None:
-            self.inertial.origin = (
-                Pose() if link.inertial.origin is None else link.inertial.origin
-            )
+        if link.inertial is not None and link.inertial.origin is None:
+            link.inertial.origin.xyz = [0, 0, 0]
+            link.inertial.origin.rpy = [0, 0, 0]
 
     def spatial_inertia(self) -> npt.ArrayLike:
         """

--- a/src/adam/model/std_factories/std_link.py
+++ b/src/adam/model/std_factories/std_link.py
@@ -14,6 +14,7 @@ class StdLink(Link):
         self.visuals = link.visuals
         self.inertial = link.inertial
         self.collisions = link.collisions
+        self.origin = link.origin
 
         # if the link has inertial properties, but the origin is None, let's add it
         if link.inertial is not None and link.inertial.origin is None:

--- a/src/adam/model/std_factories/std_link.py
+++ b/src/adam/model/std_factories/std_link.py
@@ -1,8 +1,16 @@
+from dataclasses import dataclass, field
+
 import numpy.typing as npt
 import urdf_parser_py.urdf
 
 from adam.core.spatial_math import SpatialMath
 from adam.model import Link
+
+
+@dataclass
+class Pose(urdf_parser_py.urdf.Pose):
+    xyz: list = field(default_factory=lambda: [0, 0, 0])
+    rpy: list = field(default_factory=lambda: [0, 0, 0])
 
 
 class StdLink(Link):
@@ -14,7 +22,12 @@ class StdLink(Link):
         self.visuals = link.visuals
         self.inertial = link.inertial
         self.collisions = link.collisions
-        self.origin = link.origin
+
+        # if the link has inertial properties, but the origin is None, let's add it
+        if link.inertial is not None:
+            self.inertial.origin = (
+                Pose() if link.inertial.origin is None else link.inertial.origin
+            )
 
     def spatial_inertia(self) -> npt.ArrayLike:
         """


### PR DESCRIPTION
Sometimes in the `.urdf`, a link can contain the `inertial` field (in such a case, we call it `link`, opposite to `frame`, which doesn't have `inertial`) without the origin, e.g.:
```xml
    <inertial>
      <mass value="0.06"/>
      <inertia ixx="1.6854e-05" ixy="0.0" ixz="0.0" iyy="1.6854e-05" iyz="0.0" izz="1.6854e-05"/>
    </inertial>
```

In this case, an error arises when `StdLink.spatial_inertial()` or `StdLink.homogeneus()` since `link.inertial.origin` is `None`.

This PR should fix this issue by assigning `link.inertial.origin.xyz = [0,0,0]` and `link.inertial.origin.rpy = [0,0,0]`.

@traversaro do you think that this case can be managed in this way? 