### PR TITLE
Change python3.8 dep to 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ keywords =
 packages = find:
 package_dir =
         = src
-python_requires = >=3.8
+python_requires = >=3.7
 install_requires =
         numpy >=1.20
         scipy


### PR DESCRIPTION
This PR addresses #46.

Since `python3.7` is reaching its EOL (https://www.python.org/downloads/release/python-370/) we might be forced in the future to move to a higher python version.