### PR TITLE
Use a different ci environment on Windows

### DIFF
--- a/.github/workflows/conda-forge-tests.yml
+++ b/.github/workflows/conda-forge-tests.yml
@@ -25,11 +25,20 @@ jobs:
       shell: bash -l {0}
       id: week
       run: echo "week=$(date +%Y-%U)" >> "${GITHUB_OUTPUT}"
+
     - uses: mamba-org/setup-micromamba@v1
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       with:
         environment-file: ci_env.yml
         cache-environment-key: environment-${{ steps.week.outputs.week }}-${{ matrix.os }}
+
+    - uses: mamba-org/setup-micromamba@v1
+      if: contains(matrix.os, 'windows')
+      with:
+        environment-file: ci_env_win.yml
+        cache-environment-key: environment-${{ steps.week.outputs.week }}-${{ matrix.os }}
         
+
     - name: Print packages and environment
       shell: bash -l {0}
       run: |
@@ -46,8 +55,6 @@ jobs:
       shell: bash -l {0}
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       run: |
-          # Add additional dependencies not available on Windows
-          micromamba install jax pytorch
           pytest
 
     - name: Test with pytest [Windows]

--- a/ci_env_win.yml
+++ b/ci_env_win.yml
@@ -16,5 +16,3 @@ dependencies:
   - pytest-repeat
   - icub-models
   - idyntree
-  - jax
-  - pytorch


### PR DESCRIPTION
Fix https://github.com/ami-iit/ADAM/issues/52 . The downside of this is that we are duplicating dependencies on Windows and Linux/macOS, but at least in this way we do not need to hardcode the Python version used.