### PR TITLE
Add possibility to add empty list of actuated joints

### DIFF
--- a/src/adam/casadi/computations.py
+++ b/src/adam/casadi/computations.py
@@ -20,7 +20,7 @@ class KinDynComputations:
     def __init__(
         self,
         urdfstring: str,
-        joints_name_list: list,
+        joints_name_list: list = None,
         root_link: str = "root_link",
         gravity: np.array = np.array([0.0, 0.0, -9.80665, 0.0, 0.0, 0.0]),
         f_opts: dict = dict(jit=False, jit_options=dict(flags="-Ofast")),

--- a/src/adam/jax/computations.py
+++ b/src/adam/jax/computations.py
@@ -19,7 +19,7 @@ class KinDynComputations:
     def __init__(
         self,
         urdfstring: str,
-        joints_name_list: list,
+        joints_name_list: list = None,
         root_link: str = "root_link",
         gravity: np.array = jnp.array([0, 0, -9.80665, 0, 0, 0]),
     ) -> None:

--- a/src/adam/model/model.py
+++ b/src/adam/model/model.py
@@ -23,7 +23,7 @@ class Model:
         self.N = len(self.links)
 
     @staticmethod
-    def build(factory: ModelFactory, joints_name_list: List[str]) -> "Model":
+    def build(factory: ModelFactory, joints_name_list: List[str] = None) -> "Model":
         """generates the model starting from the list of joints and the links-joints factory
 
         Args:
@@ -37,6 +37,10 @@ class Model:
         joints = factory.get_joints()
         links = factory.get_links()
         frames = factory.get_frames()
+
+        # if the joints_name_list is None, set it to the list of all the joints that are not fixed
+        if joints_name_list is None:
+            joints_name_list = [joint.name for joint in joints if joint.type != "fixed"]
 
         # check if the joints in the list are in the model
         for joint_str in joints_name_list:
@@ -131,7 +135,6 @@ class Model:
 
         console = Console()
 
-        console = Console()
         table = Table(show_header=True, header_style="bold red")
         table.add_column("Idx")
         table.add_column("Parent Link")

--- a/src/adam/model/model.py
+++ b/src/adam/model/model.py
@@ -17,6 +17,7 @@ class Model:
     joints: List[Joint]
     tree: Tree
     NDoF: int
+    actuated_joints: List[str]
 
     def __post_init__(self):
         """set the "length of the model as the number of links"""
@@ -41,6 +42,9 @@ class Model:
         # if the joints_name_list is None, set it to the list of all the joints that are not fixed
         if joints_name_list is None:
             joints_name_list = [joint.name for joint in joints if joint.type != "fixed"]
+            print(
+                f"joints_name_list is None. Setting it to the list of all the joints that are not fixed: {joints_name_list}"
+            )
 
         # check if the joints in the list are in the model
         for joint_str in joints_name_list:
@@ -69,6 +73,7 @@ class Model:
             joints=joints,
             tree=tree,
             NDoF=len(joints_name_list),
+            actuated_joints=joints_name_list,
         )
 
     def get_joints_chain(self, root: str, target: str) -> List[Joint]:

--- a/src/adam/model/model.py
+++ b/src/adam/model/model.py
@@ -38,6 +38,13 @@ class Model:
         links = factory.get_links()
         frames = factory.get_frames()
 
+        # check if the joints in the list are in the model
+        for joint_str in joints_name_list:
+            if joint_str not in [joint.name for joint in joints]:
+                raise ValueError(
+                    f"{joint_str} is not in the robot model. Check the joints_name_list"
+                )
+
         # set idx to the actuated joints
         for [idx, joint_str] in enumerate(joints_name_list):
             for joint in joints:

--- a/src/adam/numpy/computations.py
+++ b/src/adam/numpy/computations.py
@@ -18,7 +18,7 @@ class KinDynComputations:
     def __init__(
         self,
         urdfstring: str,
-        joints_name_list: list,
+        joints_name_list: list = None,
         root_link: str = "root_link",
         gravity: np.array = np.array([0, 0, -9.80665, 0, 0, 0]),
     ) -> None:

--- a/src/adam/pytorch/computations.py
+++ b/src/adam/pytorch/computations.py
@@ -19,7 +19,7 @@ class KinDynComputations:
     def __init__(
         self,
         urdfstring: str,
-        joints_name_list: list,
+        joints_name_list: list = None,
         root_link: str = "root_link",
         gravity: np.array = torch.FloatTensor([0, 0, -9.80665, 0, 0, 0]),
     ) -> None:


### PR DESCRIPTION
With this PR I want to add the possibility of not passing a list of actuated joints to the model constructor. 
In this case, all the joints that are not fixed are considered actuated joints, e.g.
```python
from adam.casadi import KinDynComputations
... 
comp = KinDynComputations(model_path)
...
```

I also added a check that verifies if all the joints passed as an argument of `KinDynComputations` are in the robot.