### PR TITLE
Update pytorch interface

### DIFF
--- a/src/adam/parametric/pytorch/computations_parametric.py
+++ b/src/adam/parametric/pytorch/computations_parametric.py
@@ -130,7 +130,7 @@ class KinDynComputationsParametric:
         Args:
             frame (str): The frame to which the fk will be computed
             base_transform (torch.tensor): The homogenous transform from base to world frame
-            joint_position (torch.tensor): The joints position
+            joint_positions (torch.tensor): The joints position
             length_multiplier (torch.tensor): The length multiplier of the parametrized links
             densities (torch.tensor): The densities of the parametrized links
 
@@ -153,7 +153,7 @@ class KinDynComputationsParametric:
             self.rbdalgos.forward_kinematics(
                 frame,
                 base_transform,
-                joint_postitions,
+                joint_positions,
             )
         ).array
 

--- a/src/adam/parametric/pytorch/computations_parametric.py
+++ b/src/adam/parametric/pytorch/computations_parametric.py
@@ -23,7 +23,9 @@ class KinDynComputationsParametric:
         joints_name_list: list,
         links_name_list: list,
         root_link: str = "root_link",
-        gravity: np.array = torch.FloatTensor([0, 0, -9.80665, 0, 0, 0]),
+        gravity: np.array = torch.tensor(
+            [0, 0, -9.80665, 0, 0, 0], dtype=torch.float64
+        ),
     ) -> None:
         """
         Args:
@@ -119,7 +121,7 @@ class KinDynComputationsParametric:
         self,
         frame,
         base_transform: torch.Tensor,
-        s: torch.Tensor,
+        joint_postitions: torch.Tensor,
         length_multiplier: torch.Tensor,
         densities: torch.Tensor,
     ) -> torch.Tensor:
@@ -128,7 +130,7 @@ class KinDynComputationsParametric:
         Args:
             frame (str): The frame to which the fk will be computed
             base_transform (torch.tensor): The homogenous transform from base to world frame
-            s (torch.tensor): The joints position
+            joints_postition (torch.tensor): The joints position
             length_multiplier (torch.tensor): The length multiplier of the parametrized links
             densities (torch.tensor): The densities of the parametrized links
 
@@ -149,7 +151,9 @@ class KinDynComputationsParametric:
         self.NDoF = self.rbdalgos.NDoF
         return (
             self.rbdalgos.forward_kinematics(
-                frame, torch.FloatTensor(base_transform), torch.FloatTensor(s)
+                frame,
+                base_transform,
+                joint_postitions,
             )
         ).array
 
@@ -414,7 +418,7 @@ class KinDynComputationsParametric:
             base_positions,
             torch.zeros(6).reshape(6, 1),
             torch.zeros(self.NDoF),
-            torch.FloatTensor(self.g),
+            self.g,
         ).array.squeeze()
 
     def get_total_mass(

--- a/src/adam/parametric/pytorch/computations_parametric.py
+++ b/src/adam/parametric/pytorch/computations_parametric.py
@@ -130,7 +130,7 @@ class KinDynComputationsParametric:
         Args:
             frame (str): The frame to which the fk will be computed
             base_transform (torch.tensor): The homogenous transform from base to world frame
-            joints_postition (torch.tensor): The joints position
+            joint_position (torch.tensor): The joints position
             length_multiplier (torch.tensor): The length multiplier of the parametrized links
             densities (torch.tensor): The densities of the parametrized links
 

--- a/src/adam/parametric/pytorch/computations_parametric.py
+++ b/src/adam/parametric/pytorch/computations_parametric.py
@@ -121,7 +121,7 @@ class KinDynComputationsParametric:
         self,
         frame,
         base_transform: torch.Tensor,
-        joint_postitions: torch.Tensor,
+        joint_positions: torch.Tensor,
         length_multiplier: torch.Tensor,
         densities: torch.Tensor,
     ) -> torch.Tensor:

--- a/src/adam/pytorch/computations.py
+++ b/src/adam/pytorch/computations.py
@@ -21,7 +21,9 @@ class KinDynComputations:
         urdfstring: str,
         joints_name_list: list = None,
         root_link: str = "root_link",
-        gravity: np.array = torch.FloatTensor([0, 0, -9.80665, 0, 0, 0]),
+        gravity: np.array = torch.tensor(
+            [0, 0, -9.80665, 0, 0, 0], dtype=torch.float64
+        ),
     ) -> None:
         """
         Args:
@@ -92,8 +94,8 @@ class KinDynComputations:
         return (
             self.rbdalgos.forward_kinematics(
                 frame,
-                torch.FloatTensor(base_transform),
-                torch.FloatTensor(joint_position),
+                base_transform,
+                joint_position,
             )
         ).array
 
@@ -240,7 +242,7 @@ class KinDynComputations:
             joint_positions,
             torch.zeros(6).reshape(6, 1),
             torch.zeros(self.NDoF),
-            torch.FloatTensor(self.g),
+            self.g,
         ).array.squeeze()
 
     def get_total_mass(self) -> float:

--- a/src/adam/pytorch/torch_like.py
+++ b/src/adam/pytorch/torch_like.py
@@ -59,6 +59,8 @@ class TorchLike(ArrayLike):
 
         if type(self) is type(other):
             return TorchLike(self.array @ other.array)
+        if isinstance(other, torch.Tensor):
+            return TorchLike(self.array @ other)
         else:
             return TorchLike(self.array @ torch.tensor(other))
 

--- a/tests/mixed/test_pytorch_mixed.py
+++ b/tests/mixed/test_pytorch_mixed.py
@@ -13,6 +13,7 @@ import torch
 from adam import Representations
 from adam.geometry import utils
 from adam.pytorch import KinDynComputations
+from adam.pytorch.torch_like import SpatialMath
 
 np.random.seed(42)
 torch.set_default_dtype(torch.float64)
@@ -71,17 +72,18 @@ kinDyn.setFloatingBase(root_link)
 kinDyn.setFrameVelocityRepresentation(idyntree.MIXED_REPRESENTATION)
 n_dofs = len(joints_name_list)
 
-# base pose quantities
-xyz = (np.random.rand(3) - 0.5) * 5
-rpy = (np.random.rand(3) - 0.5) * 5
-base_vel = (np.random.rand(6) - 0.5) * 5
+xyz = (torch.rand(3) - 0.5) * 5
+rpy = (torch.rand(3) - 0.5) * 5
+base_vel = (torch.rand(6) - 0.5) * 5
 # joints quantitites
-joints_val = (np.random.rand(n_dofs) - 0.5) * 5
-joints_dot_val = (np.random.rand(n_dofs) - 0.5) * 5
+joints_val = (torch.rand(n_dofs) - 0.5) * 5
+joints_dot_val = (torch.rand(n_dofs) - 0.5) * 5
 
-g = np.array([0, 0, -9.80665])
-H_b = utils.H_from_Pos_RPY(xyz, rpy)
-kinDyn.setRobotState(H_b, joints_val, base_vel, joints_dot_val, g)
+g = torch.tensor([0, 0, -9.80665])
+H_b = SpatialMath().H_from_Pos_RPY(xyz, rpy).array
+kinDyn.setRobotState(
+    H_b.numpy(), joints_val.numpy(), base_vel.numpy(), joints_dot_val.numpy(), g.numpy()
+)
 
 
 def test_mass_matrix():
@@ -165,8 +167,14 @@ def test_bias_force():
 
 
 def test_coriolis_term():
-    g0 = np.zeros(3)
-    kinDyn.setRobotState(H_b, joints_val, base_vel, joints_dot_val, g0)
+    g0 = torch.zeros(3)
+    kinDyn.setRobotState(
+        H_b.numpy(),
+        joints_val.numpy(),
+        base_vel.numpy(),
+        joints_dot_val.numpy(),
+        g0.numpy(),
+    )
     C_iDyn = idyntree.FreeFloatingGeneralizedTorques(kinDyn.model())
     assert kinDyn.generalizedBiasForces(C_iDyn)
     C_iDyn_np = np.concatenate(
@@ -181,9 +189,15 @@ def test_gravity_term():
     kinDyn2.loadRobotModel(robot_iDyn.model())
     kinDyn2.setFloatingBase(root_link)
     kinDyn2.setFrameVelocityRepresentation(idyntree.MIXED_REPRESENTATION)
-    base_vel0 = np.zeros(6)
-    joints_dot_val0 = np.zeros(n_dofs)
-    kinDyn2.setRobotState(H_b, joints_val, base_vel0, joints_dot_val0, g)
+    base_vel0 = torch.zeros(6)
+    joints_dot_val0 = torch.zeros(n_dofs)
+    kinDyn2.setRobotState(
+        H_b.numpy(),
+        joints_val.numpy(),
+        base_vel0.numpy(),
+        joints_dot_val0.numpy(),
+        g.numpy(),
+    )
     G_iDyn = idyntree.FreeFloatingGeneralizedTorques(kinDyn2.model())
     assert kinDyn2.generalizedBiasForces(G_iDyn)
     G_iDyn_np = np.concatenate(


### PR DESCRIPTION
The aim of this PR is to update the Pytorch interface and habilitate its use in deep learning context (i.e. use differentiability). Uniforming to `float64`.
