### PR TITLE
Fix homogeneous transform computation for prismatic joints

### DIFF
--- a/src/adam/core/spatial_math.py
+++ b/src/adam/core/spatial_math.py
@@ -267,7 +267,7 @@ class SpatialMath:
         T = self.factory.eye(4)
         R = self.R_from_RPY(rpy)
         T[:3, :3] = R
-        T[:3, 3] = xyz + q * self.factory.array(axis)
+        T[:3, 3] = self.factory.array(xyz) + q * self.factory.array(axis)
         return T
 
     def H_from_Pos_RPY(self, xyz: npt.ArrayLike, rpy: npt.ArrayLike) -> npt.ArrayLike:


### PR DESCRIPTION
With @YuchuanLu we discovered this bug preventing computations for prismatic joints. 
The sum is not defined for a `list` and an `array_like`, so I wrapped the `rpy` (that was in a list) in an array. 
I might come back later for a more smart handling. 