### PR TITLE
remove inertial filtering

### DIFF
--- a/src/adam/model/std_factories/std_model.py
+++ b/src/adam/model/std_factories/std_model.py
@@ -66,7 +66,7 @@ class URDFModelFactory(ModelFactory):
             List[StdLink]: build the list of the links
         """
         return [
-            self.build_link(l) for l in self.urdf_desc.links if l.inertial is not None
+            self.build_link(l) for l in self.urdf_desc.links
         ]
 
     def get_frames(self) -> List[StdLink]:
@@ -74,7 +74,7 @@ class URDFModelFactory(ModelFactory):
         Returns:
             List[StdLink]: build the list of the links
         """
-        return [self.build_link(l) for l in self.urdf_desc.links if l.inertial is None]
+        return [self.build_link(l) for l in self.urdf_desc.links]
 
     def build_joint(self, joint: urdf_parser_py.urdf.Joint) -> StdJoint:
         """


### PR DESCRIPTION
This filtering of links was causing a very gnarly bug as we were confused why the forward kinematics of the attached URDF was not as expected.

It seems there is no good reason to do this? It adds a lot of confusion to new users, as we expect the non-inertial links and frames to still exist.

For this URDF, for the hand we needed to add a fictitious wrist frame that coincides with the end effector tool frame.

Your code was recognizing `palm_lower` as the base link when I was really expecting `wrist_axis` to be the base link.
[leap_right.zip](https://github.com/user-attachments/files/15755399/leap_right.zip)
