### PR TITLE
Fix link filtering

### DIFF
--- a/src/adam/model/__init__.py
+++ b/src/adam/model/__init__.py
@@ -1,4 +1,4 @@
-from .abc_factories import Joint, Link, ModelFactory
+from .abc_factories import Joint, Link, ModelFactory, Inertial, Pose
 from .model import Model
 from .std_factories.std_joint import StdJoint
 from .std_factories.std_link import StdLink

--- a/src/adam/model/abc_factories.py
+++ b/src/adam/model/abc_factories.py
@@ -107,6 +107,18 @@ class Inertial:
             origin=Pose(xyz=[0.0, 0.0, 0.0], rpy=[0.0, 0.0, 0.0]),
         )
 
+    def set_mass(self, mass: npt.ArrayLike) -> "Inertial":
+        """Set the mass of the inertial object"""
+        self.mass = mass
+
+    def set_inertia(self, inertia: Inertia) -> "Inertial":
+        """Set the inertia of the inertial object"""
+        self.inertia = inertia
+
+    def set_origin(self, origin: Pose) -> "Inertial":
+        """Set the origin of the inertial object"""
+        self.origin = origin
+
 
 @dataclasses.dataclass
 class Link(abc.ABC):

--- a/src/adam/model/abc_factories.py
+++ b/src/adam/model/abc_factories.py
@@ -88,8 +88,24 @@ class Inertial:
     """Inertial description"""
 
     mass: npt.ArrayLike
-    inertia = Inertia
-    origin = Pose
+    inertia: Inertia
+    origin: Pose
+
+    @staticmethod
+    def zero() -> "Inertial":
+        """Returns an Inertial object with zero mass and inertia"""
+        return Inertial(
+            mass=0.0,
+            inertia=Inertia(
+                ixx=0.0,
+                ixy=0.0,
+                ixz=0.0,
+                iyy=0.0,
+                iyz=0.0,
+                izz=0.0,
+            ),
+            origin=Pose(xyz=[0.0, 0.0, 0.0], rpy=[0.0, 0.0, 0.0]),
+        )
 
 
 @dataclasses.dataclass

--- a/src/adam/model/std_factories/std_link.py
+++ b/src/adam/model/std_factories/std_link.py
@@ -2,7 +2,7 @@ import numpy.typing as npt
 import urdf_parser_py.urdf
 
 from adam.core.spatial_math import SpatialMath
-from adam.model import Link
+from adam.model import Link, Inertial, Pose
 
 
 class StdLink(Link):
@@ -15,10 +15,15 @@ class StdLink(Link):
         self.inertial = link.inertial
         self.collisions = link.collisions
 
+        # if the link has no inertial properties (a connecting frame), let's add them
+        if link.inertial is None:
+            link.inertial = Inertial.zero()
+
         # if the link has inertial properties, but the origin is None, let's add it
         if link.inertial is not None and link.inertial.origin is None:
-            link.inertial.origin.xyz = [0, 0, 0]
-            link.inertial.origin.rpy = [0, 0, 0]
+            link.inertial.origin = Pose(xyz=[0, 0, 0], rpy=[0, 0, 0])
+
+        self.inertial = link.inertial
 
     def spatial_inertia(self) -> npt.ArrayLike:
         """

--- a/src/adam/model/std_factories/std_model.py
+++ b/src/adam/model/std_factories/std_model.py
@@ -37,6 +37,13 @@ class URDFModelFactory(ModelFactory):
         if not path.exists():
             raise FileExistsError(path)
 
+        # Read URDF, but before passing it to urdf_parser_py get rid of all sensor tags
+        # sensor tags are valid elements of URDF (see ),
+        # but they are ignored by urdf_parser_py, that complains every time it sees one.
+        # As there is nothing to be fixed in the used models, and it is not useful
+        # to have a useless and noisy warning, let's remove before hands all the sensor elements,
+        # that anyhow are not parser by urdf_parser_py or adam
+        # See https://github.com/ami-iit/ADAM/issues/59
         with open(path, "r") as xml_file:
             xml_string = xml_file.read()
         xml_string_without_sensors_tags = urdf_remove_sensors_tags(xml_string)

--- a/src/adam/parametric/model/parametric_factories/parametric_link.py
+++ b/src/adam/parametric/model/parametric_factories/parametric_link.py
@@ -50,10 +50,11 @@ class ParametricLink(Link):
             length_multiplier=self.length_multiplier
         )
         self.mass = self.compute_mass()
-        self.inertial = Inertial(self.mass)
-        self.inertial.mass = self.mass
-        self.inertial.inertia = self.compute_inertia_parametric()
-        self.inertial.origin = self.modify_origin()
+        inertia_parametric = self.compute_inertia_parametric()
+        origin = self.modify_origin()
+        self.inertial = Inertial(
+            mass=self.mass, inertia=inertia_parametric, origin=origin
+        )
         self.update_visuals()
 
     def get_principal_length(self):


### PR DESCRIPTION
This PR fixes #82. 
The link filtering was done by selecting the links with inertia (and frames without inertia; see https://github.com/ami-iit/adam/pull/83#issuecomment-2157581130).

With this fix, massless links with children are also considered connecting links, and the tree is not broken. 