### PR TITLE
Enable common subexpression elimination of casadi functions

### DIFF
--- a/ci_env.yml
+++ b/ci_env.yml
@@ -5,7 +5,7 @@ dependencies:
   - python >=3.7
   - numpy
   - scipy
-  - casadi
+  - casadi >=3.6
   - prettytable
   - urdfdom-py
   - pip

--- a/ci_env_win.yml
+++ b/ci_env_win.yml
@@ -5,7 +5,7 @@ dependencies:
   - python >=3.7
   - numpy
   - scipy
-  - casadi
+  - casadi >=3.6
   - prettytable
   - urdfdom-py
   - pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ python_requires = >=3.7
 install_requires =
         numpy >=1.20
         scipy
-        casadi
+        casadi >=3.6
         prettytable
         urdf_parser_py
 

--- a/src/adam/casadi/computations.py
+++ b/src/adam/casadi/computations.py
@@ -24,7 +24,7 @@ class KinDynComputations:
         root_link: str = "root_link",
         cs_type: Union[cs.SX, cs.DM] = cs.SX,
         gravity: np.array = np.array([0.0, 0.0, -9.80665, 0.0, 0.0, 0.0]),
-        f_opts: dict = dict(jit=False, jit_options=dict(flags="-Ofast")),
+        f_opts: dict = dict(jit=False, jit_options=dict(flags="-Ofast"), cse=True),
     ) -> None:
         """
         Args:


### PR DESCRIPTION
Enable common subexpression elimination by default to eliminate redundant computations efficiently. This feature was introduced in [CasADi 3.6](https://github.com/casadi/casadi/releases/tag/3.6.0).
I changed the minimum supported version of Casadi to `v3.6`