### PR TITLE
Remove casadi.MX 

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,20 @@ w_H_b = np.eye(4)
 joints = np.ones(len(joints_name_list))
 M = kinDyn.mass_matrix_fun()
 print(M(w_H_b, joints))
+
+# If you want to use the symbolic version
+w_H_b = cs.SX.eye(4)
+joints = cs.SX.sym('joints', len(joints_name_list))
+M = kinDyn.mass_matrix_fun()
+print(M(w_H_b, joints))
+
+# This is usable also with casadi.MX
+w_H_b = cs.MX.eye(4)
+joints = cs.MX.sym('joints', len(joints_name_list))
+M = kinDyn.mass_matrix_fun()
+print(M(w_H_b, joints))
+
+
 ```
 
 ### PyTorch interface

--- a/src/adam/casadi/casadi_like.py
+++ b/src/adam/casadi/casadi_like.py
@@ -104,17 +104,16 @@ class CasadiLike(ArrayLike):
 
 class CasadiLikeFactory(ArrayLikeFactory):
 
-    def __init__(self, cs_type: Union[cs.SX, cs.DM]):
-        self.cs_type = cs_type
-
-    def zeros(self, *x: int) -> "CasadiLike":
+    @staticmethod
+    def zeros(*x: int) -> "CasadiLike":
         """
         Returns:
             CasadiLike: Matrix of zeros of dim *x
         """
-        return CasadiLike(self.cs_type.zeros(*x))
+        return CasadiLike(cs.SX.zeros(*x))
 
-    def eye(self, x: int) -> "CasadiLike":
+    @staticmethod
+    def eye(x: int) -> "CasadiLike":
         """
         Args:
             x (int): matrix dimension
@@ -122,20 +121,21 @@ class CasadiLikeFactory(ArrayLikeFactory):
         Returns:
             CasadiLike: Identity matrix
         """
-        return CasadiLike(self.cs_type.eye(x))
+        return CasadiLike(cs.SX.eye(x))
 
-    def array(self, *x) -> "CasadiLike":
+    @staticmethod
+    def array(*x) -> "CasadiLike":
         """
         Returns:
             CasadiLike: Vector wrapping *x
         """
-        return CasadiLike(self.cs_type(*x))
+        return CasadiLike(cs.SX(*x))
 
 
 class SpatialMath(SpatialMath):
 
-    def __init__(self, cs_type: Union[cs.SX, cs.DM]):
-        super().__init__(CasadiLikeFactory(cs_type))
+    def __init__(self):
+        super().__init__(CasadiLikeFactory)
 
     @staticmethod
     def skew(x: Union["CasadiLike", npt.ArrayLike]) -> "CasadiLike":

--- a/src/adam/casadi/computations.py
+++ b/src/adam/casadi/computations.py
@@ -22,7 +22,6 @@ class KinDynComputations:
         urdfstring: str,
         joints_name_list: list = None,
         root_link: str = "root_link",
-        cs_type: Union[cs.SX, cs.DM] = cs.SX,
         gravity: np.array = np.array([0.0, 0.0, -9.80665, 0.0, 0.0, 0.0]),
         f_opts: dict = dict(jit=False, jit_options=dict(flags="-Ofast"), cse=True),
     ) -> None:
@@ -32,7 +31,7 @@ class KinDynComputations:
             joints_name_list (list): list of the actuated joints
             root_link (str, optional): the first link. Defaults to 'root_link'.
         """
-        math = SpatialMath(cs_type)
+        math = SpatialMath()
         factory = URDFModelFactory(path=urdfstring, math=math)
         model = Model.build(factory=factory, joints_name_list=joints_name_list)
         self.rbdalgos = RBDAlgorithms(model=model, math=math)
@@ -239,7 +238,7 @@ class KinDynComputations:
             joint_positions (Union[cs.SX, cs.DM]): The joints position
 
         Returns:
-            M (jax): Mass Matrix
+            M (Union[cs.SX, cs.DM]): Mass Matrix
         """
         [M, _] = self.rbdalgos.crba(base_transform, joint_positions)
         return M.array

--- a/src/adam/casadi/computations.py
+++ b/src/adam/casadi/computations.py
@@ -240,6 +240,11 @@ class KinDynComputations:
         Returns:
             M (Union[cs.SX, cs.DM]): Mass Matrix
         """
+        if isinstance(base_transform, cs.MX) and isinstance(joint_positions, cs.MX):
+            raise ValueError(
+                "You are using casadi MX. Please use the function KinDynComputations.mass_matrix_fun()"
+            )
+
         [M, _] = self.rbdalgos.crba(base_transform, joint_positions)
         return M.array
 
@@ -255,6 +260,11 @@ class KinDynComputations:
         Returns:
             Jcc (Union[cs.SX, cs.DM]): Centroidal Momentum matrix
         """
+        if isinstance(base_transform, cs.MX) and isinstance(joint_positions, cs.MX):
+            raise ValueError(
+                "You are using casadi MX. Please use the function KinDynComputations.centroidal_momentum_matrix_fun()"
+            )
+
         [_, Jcm] = self.rbdalgos.crba(base_transform, joint_positions)
         return Jcm.array
 
@@ -268,6 +278,11 @@ class KinDynComputations:
         Returns:
             J (Union[cs.SX, cs.DM]): The Jacobian between the root and the frame
         """
+        if isinstance(joint_positions, cs.MX):
+            raise ValueError(
+                "You are using casadi MX. Please use the function KinDynComputations.relative_jacobian_fun()"
+            )
+
         return self.rbdalgos.relative_jacobian(frame, joint_positions).array
 
     def jacobian_dot(
@@ -290,6 +305,15 @@ class KinDynComputations:
         Returns:
             Jdot (Union[cs.SX, cs.DM]): The Jacobian derivative relative to the frame
         """
+        if (
+            isinstance(base_transform, cs.MX)
+            and isinstance(joint_positions, cs.MX)
+            and isinstance(base_velocity, cs.MX)
+            and isinstance(joint_velocities, cs.MX)
+        ):
+            raise ValueError(
+                "You are using casadi MX. Please use the function KinDynComputations.jacobian_dot_fun()"
+            )
         return self.rbdalgos.jacobian_dot(
             frame, base_transform, joint_positions, base_velocity, joint_velocities
         ).array
@@ -310,6 +334,11 @@ class KinDynComputations:
         Returns:
             H (Union[cs.SX, cs.DM]): The fk represented as Homogenous transformation matrix
         """
+        if isinstance(base_transform, cs.MX) and isinstance(joint_positions, cs.MX):
+            raise ValueError(
+                "You are using casadi MX. Please use the function KinDynComputations.forward_kinematics_fun()"
+            )
+
         return self.rbdalgos.forward_kinematics(
             frame, base_transform, joint_positions
         ).array
@@ -325,6 +354,11 @@ class KinDynComputations:
         Returns:
             J_tot (Union[cs.SX, cs.DM]): The Jacobian relative to the frame
         """
+        if isinstance(base_transform, cs.MX) and isinstance(joint_positions, cs.MX):
+            raise ValueError(
+                "You are using casadi MX. Please use the function KinDynComputations.jacobian_fun()"
+            )
+
         return self.rbdalgos.jacobian(frame, base_transform, joint_positions).array
 
     def bias_force(
@@ -346,6 +380,16 @@ class KinDynComputations:
         Returns:
             h (Union[cs.SX, cs.DM]): the bias force
         """
+        if (
+            isinstance(base_transform, cs.MX)
+            and isinstance(joint_positions, cs.MX)
+            and isinstance(base_velocity, cs.MX)
+            and isinstance(joint_velocities, cs.MX)
+        ):
+            raise ValueError(
+                "You are using casadi MX. Please use the function KinDynComputations.bias_force_fun()"
+            )
+
         return self.rbdalgos.rnea(
             base_transform, joint_positions, base_velocity, joint_velocities, self.g
         ).array
@@ -369,6 +413,16 @@ class KinDynComputations:
         Returns:
             C (Union[cs.SX, cs.DM]): the Coriolis term
         """
+        if (
+            isinstance(base_transform, cs.MX)
+            and isinstance(joint_positions, cs.MX)
+            and isinstance(base_velocity, cs.MX)
+            and isinstance(joint_velocities, cs.MX)
+        ):
+            raise ValueError(
+                "You are using casadi MX. Please use the function KinDynComputations.coriolis_term_fun()"
+            )
+
         return self.rbdalgos.rnea(
             base_transform,
             joint_positions,
@@ -390,6 +444,11 @@ class KinDynComputations:
         Returns:
             G (Union[cs.SX, cs.DM]): the gravity term
         """
+        if isinstance(base_transform, cs.MX) and isinstance(joint_positions, cs.MX):
+            raise ValueError(
+                "You are using casadi MX. Please use the function KinDynComputations.gravity_term_fun()"
+            )
+
         return self.rbdalgos.rnea(
             base_transform,
             joint_positions,
@@ -410,4 +469,9 @@ class KinDynComputations:
         Returns:
             CoM (Union[cs.SX, cs.DM]): The CoM position
         """
+        if isinstance(base_transform, cs.MX) and isinstance(joint_positions, cs.MX):
+            raise ValueError(
+                "You are using casadi MX. Please use the function KinDynComputations.CoM_position_fun()"
+            )
+
         return self.rbdalgos.CoM_position(base_transform, joint_positions).array

--- a/src/adam/parametric/casadi/computations_parametric.py
+++ b/src/adam/parametric/casadi/computations_parametric.py
@@ -24,7 +24,6 @@ class KinDynComputationsParametric:
         joints_name_list: list,
         links_name_list: list,
         root_link: str = "root_link",
-        cs_type: Union[cs.SX, cs.DM] = cs.SX,
         gravity: np.array = np.array([0.0, 0.0, -9.80665, 0.0, 0.0, 0.0]),
         f_opts: dict = dict(jit=False, jit_options=dict(flags="-Ofast")),
     ) -> None:
@@ -35,7 +34,7 @@ class KinDynComputationsParametric:
             links_name_list (list): list of the parametrized links
             root_link (str, optional): the first link. Defaults to 'root_link'.
         """
-        math = SpatialMath(cs_type)
+        math = SpatialMath()
         n_param_links = len(links_name_list)
         self.densities = cs.SX.sym("densities", n_param_links)
         self.length_multiplier = cs.SX.sym("length_multiplier", n_param_links)


### PR DESCRIPTION
I did some tests using `casadi.MX`, and I figured out that that MX is not really elastic. For example, a "numeric MX" (an MX filled with numbers) cannot be converted to a DM, while a "numeric SX" can. 
Also, MX and SX cannot be converted to each other.

On the other hand, passing through a `casadi.Function` allows the user to choose the type of the input and have the output of the same type, i.e.
```python
a_sx = cs.SX.sym('a')
b_sx = cs.SX.sym('b')

fun = cs.Function('fun', [a,b], [a+b])

c_sx = fun(a_sx, b_sx)

a_mx = cs.MX.sym('a')
b_mx = cs.MX.sym('b')
 
c_mx = fun(a_mx, b_mx)

# this should be possible also with casadi.DM and numpy 
```

For this reason (and also because I've not implemented sufficient tests) I want to revert #84, for now, and just do the computation with `casadi.SX` and exploit the `casadi.Function`. 

