### PR TITLE
Update GitHub Actions and runners OS

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: black
         uses: psf/black@stable
         with:

--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - run: git fetch --prune --unshallow
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -36,7 +36,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/ .
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -48,7 +48,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
@@ -66,7 +66,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist

--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -18,7 +18,7 @@ jobs:
         python-version:
           - 3.8
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
 
     steps:
       - uses: actions/checkout@master
@@ -43,7 +43,7 @@ jobs:
 
   deploy_test_PyPI:
     name: 📦 Deploy to TestPyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build_wheels]
     if: github.ref == 'refs/heads/main'
     steps:
@@ -61,7 +61,7 @@ jobs:
 
   deploy_PyPI:
     name: 📦 Deploy to PyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build_wheels]
     if: startsWith(github.ref, 'refs/tags')
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: [3.11]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
CI were failing due to a deprecated version of some GitHub Actions used.

```shell
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. 
Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```