### PR TITLE
Update pypi-ci.yml

### DIFF
--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -44,8 +44,9 @@ jobs:
   deploy_test_PyPI:
     name: 📦 Deploy to TestPyPI
     runs-on: ubuntu-22.04
-    needs: [build_wheels]
-    if: github.ref == 'refs/heads/main'
+    permissions:
+        id-token: write
+      
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -54,16 +55,17 @@ jobs:
           path: dist
 
       - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
+          skip-existing: true
 
   deploy_PyPI:
     name: 📦 Deploy to PyPI
     runs-on: ubuntu-22.04
-    needs: [build_wheels]
-    if: startsWith(github.ref, 'refs/tags')
+    permissions:
+        id-token: write
+    
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -72,6 +74,6 @@ jobs:
           path: dist
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
This PR should fix https://github.com/ami-iit/adam/actions/runs/11518056399, which gives the following:

```bash
You are using `pypa/gh-action-pypi-publish@master`. The `master` branch of this project has been sunset and will not receive any updates, not even security bug fixes. Please, make sure to use a supported version. If you want to pin to v1 major version, use `pypa/gh-action-pypi-publish@release/v1`. If you feel adventurous, you may opt to use use `pypa/gh-action-pypi-publish@unstable/v1` instead. A more general recommendation is to pin to exact tags or commit SHAs.
```

Following https://github.com/marketplace/actions/pypi-publish#trusted-publishing I updated the logic of the pypi workflow.

The CI seems to work now.