### PR TITLE
Raise error if a non-existing string-type path is passed

### DIFF
--- a/src/adam/model/std_factories/std_model.py
+++ b/src/adam/model/std_factories/std_model.py
@@ -36,7 +36,7 @@ def get_xml_string(path: str | pathlib.Path):
 
     # Checking if it is a path or an urdf
     if not isPath:
-        if len(path) <= MAX_PATH:
+        if len(path) <= MAX_PATH and "<robot" not in path:
             path = pathlib.Path(path)
             isPath = True
         else:
@@ -49,11 +49,7 @@ def get_xml_string(path: str | pathlib.Path):
                     break
 
     if isPath:
-        if not path.is_file():
-            raise FileExistsError(path)
-
-        with path.open() as xml_file:
-            xml_string = xml_file.read()
+        xml_string = path.read_text()
 
     if not isPath and not isUrdf:
         raise ValueError(

--- a/src/adam/model/std_factories/std_model.py
+++ b/src/adam/model/std_factories/std_model.py
@@ -36,7 +36,7 @@ def get_xml_string(path: str | pathlib.Path):
 
     # Checking if it is a path or an urdf
     if not isPath:
-        if len(path) <= MAX_PATH and os.path.exists(path):
+        if len(path) <= MAX_PATH:
             path = pathlib.Path(path)
             isPath = True
         else:


### PR DESCRIPTION
This pull request includes a small change to the `get_xml_string` function in the `src/adam/model/std_factories/std_model.py` file. The change simplifies the condition for converting a string to a `pathlib.Path` object by removing the redundant check for the existence of the path. In this way, an error will be raised when a non-existing string-type path is passed