### PR TITLE
Refactor `get_xml_string` function to handle non-existent paths

### DIFF
--- a/src/adam/model/std_factories/std_model.py
+++ b/src/adam/model/std_factories/std_model.py
@@ -1,7 +1,8 @@
-import pathlib
-from typing import List
-import xml.etree.ElementTree as ET
 import os
+import pathlib
+import xml.etree.ElementTree as ET
+from typing import List
+
 import urdf_parser_py.urdf
 
 from adam.core.spatial_math import SpatialMath
@@ -36,9 +37,12 @@ def get_xml_string(path: str | pathlib.Path):
 
     # Checking if it is a path or an urdf
     if not isPath:
-        if len(path) <= MAX_PATH and os.path.exists(path):
-            path = pathlib.Path(path)
-            isPath = True
+        if len(path) <= MAX_PATH:
+            if os.path.exists(path):
+                path = pathlib.Path(path)
+                isPath = True
+            else:
+                raise FileExistsError(path)
         else:
             root = ET.fromstring(path)
 


### PR DESCRIPTION
This PR refactors the `get_xml_string` function in `std_model.py` to increase its robustness with respect to non existent model paths.

<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--104.org.readthedocs.build/en/104/

<!-- readthedocs-preview adam-docs end -->