### PR TITLE
Fix PyPI deployment on CI

### DIFF
--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -44,9 +44,9 @@ jobs:
   deploy_test_PyPI:
     name: 📦 Deploy to TestPyPI
     runs-on: ubuntu-22.04
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     permissions:
-        id-token: write
-      
+      id-token: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -63,8 +63,9 @@ jobs:
   deploy_PyPI:
     name: 📦 Deploy to PyPI
     runs-on: ubuntu-22.04
+    if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
     permissions:
-        id-token: write
+      id-token: write
     
     steps:
       - name: Download artifacts


### PR DESCRIPTION
This PR fixes the PyPI deployment on CI. In this way, the workflow will be disabled for the forks of this repository (See failing job on https://github.com/ami-iit/adam/actions/runs/11667895168/job/32486274590?pr=103)

<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--105.org.readthedocs.build/en/105/

<!-- readthedocs-preview adam-docs end -->