### PR TITLE
Fix PyPi test and upload action

### DIFF
--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -1,6 +1,7 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 
 on:
+  workflow_dispatch:
   push:
     branches: ["**"]
     tags-ignore: ["**"]

--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-${{ matrix.os }}-${{ matrix.arch }}
           path: dist
 
   deploy_test_PyPI:
@@ -51,7 +51,8 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: dist
+          pattern: dist-*
+          merge-multiple: true
           path: dist
 
       - name: Publish distribution 📦 to Test PyPI
@@ -71,7 +72,8 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: dist
+          pattern: dist-*
+          merge-multiple: true
           path: dist
 
       - name: Publish distribution 📦 to PyPI


### PR DESCRIPTION
The pypi action fails with:
```
Unable to download artifact(s): Artifact not found for name: dist
        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.
        For more information, visit the GitHub Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md
```

This PR wants to solve this (but I'm not sure it works).
I should also change the logic triggering the `test_PyPi`, ideally with and additional manual trigger.
See: https://github.com/actions/download-artifact?tab=readme-ov-file#download-multiple-filtered-artifacts-to-the-same-directory



<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--107.org.readthedocs.build/en/107/

<!-- readthedocs-preview adam-docs end -->