### PR TITLE
Fix casadi example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ w_H_f_batch = jitted_vmapped_frame_fk(w_H_b_batch, joints_batch)
 ### CasADi interface
 
 ```python
+import casadi as cs
 import adam
 from adam.casadi import KinDynComputations
 import icub_models


### PR DESCRIPTION
The example used `cs.SX.eye(4)` but never imported casadi as `cs` .

<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--113.org.readthedocs.build/en/113/

<!-- readthedocs-preview adam-docs end -->