### PR TITLE
Fix comments and function arguments

### DIFF
--- a/src/adam/casadi/computations.py
+++ b/src/adam/casadi/computations.py
@@ -294,7 +294,7 @@ class KinDynComputations:
             frame (str): The frame to which the jacobian will be computed
             base_transform (cs.SX): The homogenous transform from base to world frame
             joint_positions (cs.SX): The joints position
-            base_velocity (cs.SX): The base velocity in mixed representation
+            base_velocity (cs.SX): The base velocity
             joint_velocities (cs.SX): The joint velocities
 
         Returns:
@@ -369,7 +369,7 @@ class KinDynComputations:
         Args:
             base_transform (cs.SX): The homogenous transform from base to world frame
             joint_positions (cs.SX): The joints position
-            base_velocity (cs.SX): The base velocity in mixed representation
+            base_velocity (cs.SX): The base velocity
             joint_velocities (cs.SX): The joints velocity
 
         Returns:
@@ -402,7 +402,7 @@ class KinDynComputations:
         Args:
             base_transform (cs.SX): The homogenous transform from base to world frame
             joint_positions (cs.SX): The joints position
-            base_velocity (cs.SX): The base velocity in mixed representation
+            base_velocity (cs.SX): The base velocity
             joint_velocities (cs.SX): The joints velocity
 
         Returns:

--- a/src/adam/casadi/computations.py
+++ b/src/adam/casadi/computations.py
@@ -36,7 +36,11 @@ class KinDynComputations:
         self.g = gravity
         self.f_opts = f_opts
         if root_link is not None:
-            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/casadi/computations.py
+++ b/src/adam/casadi/computations.py
@@ -1,5 +1,7 @@
 # Copyright (C) Istituto Italiano di Tecnologia (IIT). All rights reserved.
 
+import warnings
+
 import casadi as cs
 import numpy as np
 
@@ -34,9 +36,7 @@ class KinDynComputations:
         self.g = gravity
         self.f_opts = f_opts
         if root_link is not None:
-            raise DeprecationWarning(
-                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF"
-            )
+            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/core/rbd_algorithms.py
+++ b/src/adam/core/rbd_algorithms.py
@@ -8,8 +8,7 @@ from adam.model import Model, Node
 
 
 class RBDAlgorithms:
-    """This is a small class that implements Rigid body algorithms retrieving robot quantities, for Floating Base systems - as humanoid robots.
-    """
+    """This is a small class that implements Rigid body algorithms retrieving robot quantities, for Floating Base systems - as humanoid robots."""
 
     def __init__(self, model: Model, math: SpatialMath) -> None:
         """

--- a/src/adam/core/rbd_algorithms.py
+++ b/src/adam/core/rbd_algorithms.py
@@ -247,7 +247,7 @@ class RBDAlgorithms:
             frame (str): The frame to which the jacobian will be computed
             base_transform (npt.ArrayLike): The homogenous transform from base to world frame
             joint_positions (npt.ArrayLike): The joints position
-            base_velocity (npt.ArrayLike): The base velocity in mixed representation
+            base_velocity (npt.ArrayLike): The base velocity
             joint_velocities (npt.ArrayLike): The joints velocity
 
         Returns:

--- a/src/adam/core/rbd_algorithms.py
+++ b/src/adam/core/rbd_algorithms.py
@@ -8,8 +8,7 @@ from adam.model import Model, Node
 
 
 class RBDAlgorithms:
-    """This is a small class that implements Rigid body algorithms retrieving robot quantities represented
-    in mixed representation, for Floating Base systems - as humanoid robots.
+    """This is a small class that implements Rigid body algorithms retrieving robot quantities, for Floating Base systems - as humanoid robots.
     """
 
     def __init__(self, model: Model, math: SpatialMath) -> None:
@@ -370,7 +369,7 @@ class RBDAlgorithms:
             frame (str): The frame to which the jacobian will be computed
             base_transform (T): The homogenous transform from base to world frame
             joint_positions (T): The joints position
-            base_velocity (T): The base velocity in mixed representation
+            base_velocity (T): The base velocity
             joint_velocities (T): The joints velocity
             g (T): The 6D gravity acceleration
 

--- a/src/adam/jax/computations.py
+++ b/src/adam/jax/computations.py
@@ -34,7 +34,11 @@ class KinDynComputations:
         self.NDoF = self.rbdalgos.NDoF
         self.g = gravity
         if root_link is not None:
-            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/jax/computations.py
+++ b/src/adam/jax/computations.py
@@ -1,5 +1,7 @@
 # Copyright (C) Istituto Italiano di Tecnologia (IIT). All rights reserved.
 
+import warnings
+
 import jax.numpy as jnp
 import numpy as np
 
@@ -32,9 +34,7 @@ class KinDynComputations:
         self.NDoF = self.rbdalgos.NDoF
         self.g = gravity
         if root_link is not None:
-            raise DeprecationWarning(
-                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF"
-            )
+            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/numpy/computations.py
+++ b/src/adam/numpy/computations.py
@@ -1,5 +1,6 @@
 # Copyright (C) Istituto Italiano di Tecnologia (IIT). All rights reserved.
 
+import warnings
 
 import numpy as np
 
@@ -32,9 +33,7 @@ class KinDynComputations:
         self.NDoF = model.NDoF
         self.g = gravity
         if root_link is not None:
-            raise DeprecationWarning(
-                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF"
-            )
+            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/numpy/computations.py
+++ b/src/adam/numpy/computations.py
@@ -33,7 +33,11 @@ class KinDynComputations:
         self.NDoF = model.NDoF
         self.g = gravity
         if root_link is not None:
-            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/parametric/casadi/computations_parametric.py
+++ b/src/adam/parametric/casadi/computations_parametric.py
@@ -1,5 +1,7 @@
 # Copyright (C) Istituto Italiano di Tecnologia (IIT). All rights reserved.
 
+import warnings
+
 import casadi as cs
 import numpy as np
 
@@ -49,9 +51,7 @@ class KinDynComputationsParametric:
         self.g = gravity
         self.f_opts = f_opts
         if root_link is not None:
-            raise DeprecationWarning(
-                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF"
-            )
+            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/parametric/casadi/computations_parametric.py
+++ b/src/adam/parametric/casadi/computations_parametric.py
@@ -51,7 +51,11 @@ class KinDynComputationsParametric:
         self.g = gravity
         self.f_opts = f_opts
         if root_link is not None:
-            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/parametric/jax/computations_parametric.py
+++ b/src/adam/parametric/jax/computations_parametric.py
@@ -1,5 +1,7 @@
 # Copyright (C) Istituto Italiano di Tecnologia (IIT). All rights reserved.
 
+import warnings
+
 import jax.numpy as jnp
 import numpy as np
 from jax import grad, jit, vmap
@@ -38,9 +40,7 @@ class KinDynComputationsParametric:
         self.joints_name_list = joints_name_list
         self.representation = Representations.MIXED_REPRESENTATION  # Default
         if root_link is not None:
-            raise DeprecationWarning(
-                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF"
-            )
+            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/parametric/jax/computations_parametric.py
+++ b/src/adam/parametric/jax/computations_parametric.py
@@ -40,7 +40,11 @@ class KinDynComputationsParametric:
         self.joints_name_list = joints_name_list
         self.representation = Representations.MIXED_REPRESENTATION  # Default
         if root_link is not None:
-            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/parametric/numpy/computations_parametric.py
+++ b/src/adam/parametric/numpy/computations_parametric.py
@@ -38,7 +38,11 @@ class KinDynComputationsParametric:
         self.joints_name_list = joints_name_list
         self.representation = Representations.MIXED_REPRESENTATION  # Default
         if root_link is not None:
-            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/parametric/numpy/computations_parametric.py
+++ b/src/adam/parametric/numpy/computations_parametric.py
@@ -1,5 +1,7 @@
 # Copyright (C) Istituto Italiano di Tecnologia (IIT). All rights reserved.
 
+import warnings
+
 import numpy as np
 
 from adam.core.constants import Representations
@@ -36,9 +38,7 @@ class KinDynComputationsParametric:
         self.joints_name_list = joints_name_list
         self.representation = Representations.MIXED_REPRESENTATION  # Default
         if root_link is not None:
-            raise DeprecationWarning(
-                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF"
-            )
+            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/parametric/pytorch/computations_parametric.py
+++ b/src/adam/parametric/pytorch/computations_parametric.py
@@ -41,7 +41,11 @@ class KinDynComputationsParametric:
         self.urdfstring = urdfstring
         self.representation = Representations.MIXED_REPRESENTATION  # Default
         if root_link is not None:
-            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/parametric/pytorch/computations_parametric.py
+++ b/src/adam/parametric/pytorch/computations_parametric.py
@@ -1,5 +1,7 @@
 # Copyright (C) Istituto Italiano di Tecnologia (IIT). All rights reserved.
 
+import warnings
+
 import numpy as np
 import torch
 
@@ -39,9 +41,7 @@ class KinDynComputationsParametric:
         self.urdfstring = urdfstring
         self.representation = Representations.MIXED_REPRESENTATION  # Default
         if root_link is not None:
-            raise DeprecationWarning(
-                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF"
-            )
+            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/pytorch/computation_batch.py
+++ b/src/adam/pytorch/computation_batch.py
@@ -30,7 +30,7 @@ class KinDynComputationsBatch:
         Args:
             urdfstring (str): path of the urdf
             joints_name_list (list): list of the actuated joints
-            root_link (str, optional): the first link. Defaults to 'root_link'.
+            root_link (str, optional): Deprecated. The root link is automatically chosen as the link with no parent in the URDF. Defaults to None.
         """
         math = SpatialMath()
         factory = URDFModelFactory(path=urdfstring, math=math)
@@ -39,6 +39,11 @@ class KinDynComputationsBatch:
         self.NDoF = self.rbdalgos.NDoF
         self.g = gravity
         self.funcs = {}
+        if root_link is not None:
+            raise DeprecationWarning(
+                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF"
+            )
+        
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/pytorch/computation_batch.py
+++ b/src/adam/pytorch/computation_batch.py
@@ -23,7 +23,7 @@ class KinDynComputationsBatch:
         self,
         urdfstring: str,
         joints_name_list: list = None,
-        root_link: str = "root_link",
+        root_link: str = None,
         gravity: np.array = jnp.array([0, 0, -9.80665, 0, 0, 0]),
     ) -> None:
         """

--- a/src/adam/pytorch/computation_batch.py
+++ b/src/adam/pytorch/computation_batch.py
@@ -2,6 +2,8 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
+import warnings
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -40,10 +42,8 @@ class KinDynComputationsBatch:
         self.g = gravity
         self.funcs = {}
         if root_link is not None:
-            raise DeprecationWarning(
-                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF"
-            )
-        
+            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
+
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/pytorch/computation_batch.py
+++ b/src/adam/pytorch/computation_batch.py
@@ -42,8 +42,11 @@ class KinDynComputationsBatch:
         self.g = gravity
         self.funcs = {}
         if root_link is not None:
-            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
-
+            warnings.warn(
+                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/pytorch/computations.py
+++ b/src/adam/pytorch/computations.py
@@ -37,7 +37,11 @@ class KinDynComputations:
         self.NDoF = self.rbdalgos.NDoF
         self.g = gravity
         if root_link is not None:
-            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def set_frame_velocity_representation(
         self, representation: Representations

--- a/src/adam/pytorch/computations.py
+++ b/src/adam/pytorch/computations.py
@@ -50,7 +50,7 @@ class KinDynComputations:
         self.rbdalgos.set_frame_velocity_representation(representation)
 
     def mass_matrix(
-        self, base_transform: torch.Tensor, joint_position: torch.Tensor
+        self, base_transform: torch.Tensor, joint_positions: torch.Tensor
     ) -> torch.Tensor:
         """Returns the Mass Matrix functions computed the CRBA
 
@@ -61,11 +61,11 @@ class KinDynComputations:
         Returns:
             M (torch.tensor): Mass Matrix
         """
-        [M, _] = self.rbdalgos.crba(base_transform, joint_position)
+        [M, _] = self.rbdalgos.crba(base_transform, joint_positions)
         return M.array
 
     def centroidal_momentum_matrix(
-        self, base_transform: torch.Tensor, joint_position: torch.Tensor
+        self, base_transform: torch.Tensor, joint_positions: torch.Tensor
     ) -> torch.Tensor:
         """Returns the Centroidal Momentum Matrix functions computed the CRBA
 
@@ -76,11 +76,11 @@ class KinDynComputations:
         Returns:
             Jcc (torch.tensor): Centroidal Momentum matrix
         """
-        [_, Jcm] = self.rbdalgos.crba(base_transform, joint_position)
+        [_, Jcm] = self.rbdalgos.crba(base_transform, joint_positions)
         return Jcm.array
 
     def forward_kinematics(
-        self, frame, base_transform: torch.Tensor, joint_position: torch.Tensor
+        self, frame, base_transform: torch.Tensor, joint_positions: torch.Tensor
     ) -> torch.Tensor:
         """Computes the forward kinematics relative to the specified frame
 
@@ -96,7 +96,7 @@ class KinDynComputations:
             self.rbdalgos.forward_kinematics(
                 frame,
                 base_transform,
-                joint_position,
+                joint_positions,
             )
         ).array
 
@@ -177,7 +177,7 @@ class KinDynComputations:
         base_velocity: torch.Tensor,
         joint_velocities: torch.Tensor,
     ) -> torch.Tensor:
-        """Returns the bias force of the floating-base dynamics ejoint_positionsuation,
+        """Returns the bias force of the floating-base dynamics equation,
         using a reduced RNEA (no acceleration and external forces)
 
         Args:
@@ -204,7 +204,7 @@ class KinDynComputations:
         base_velocity: torch.Tensor,
         joint_velocities: torch.Tensor,
     ) -> torch.Tensor:
-        """Returns the coriolis term of the floating-base dynamics ejoint_positionsuation,
+        """Returns the coriolis term of the floating-base dynamics equation,
         using a reduced RNEA (no acceleration and external forces)
 
         Args:
@@ -228,7 +228,7 @@ class KinDynComputations:
     def gravity_term(
         self, base_transform: torch.Tensor, joint_positions: torch.Tensor
     ) -> torch.Tensor:
-        """Returns the gravity term of the floating-base dynamics ejoint_positionsuation,
+        """Returns the gravity term of the floating-base dynamics equation,
         using a reduced RNEA (no acceleration and external forces)
 
         Args:

--- a/src/adam/pytorch/computations.py
+++ b/src/adam/pytorch/computations.py
@@ -1,6 +1,8 @@
 # Copyright (C) Istituto Italiano di Tecnologia (IIT). All rights reserved.
 
 
+import warnings
+
 import numpy as np
 import torch
 
@@ -35,9 +37,7 @@ class KinDynComputations:
         self.NDoF = self.rbdalgos.NDoF
         self.g = gravity
         if root_link is not None:
-            raise DeprecationWarning(
-                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF"
-            )
+            warnings.warn("The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF", DeprecationWarning, stacklevel=2)
 
     def set_frame_velocity_representation(
         self, representation: Representations


### PR DESCRIPTION
@GiulioRomualdi spotted some wrong arguments in the pytorch interface. 
Fixed `joint_position` to `joint_postions` as in the other functions.
Took the occasion also to fix other wrong comments.

Changing also the `raise DeprecationWarning` for the use of the `root_link` introduced in #114 to a more mild `warning.warn()`. 

<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--116.org.readthedocs.build/en/116/

<!-- readthedocs-preview adam-docs end -->