### PR TITLE
Refactor gravity initialization and update post-init conversion to use default tensor type

### DIFF
--- a/src/adam/parametric/pytorch/computations_parametric.py
+++ b/src/adam/parametric/pytorch/computations_parametric.py
@@ -23,9 +23,7 @@ class KinDynComputationsParametric:
         joints_name_list: list,
         links_name_list: list,
         root_link: str = None,
-        gravity: np.array = torch.tensor(
-            [0, 0, -9.80665, 0, 0, 0], dtype=torch.float64
-        ),
+        gravity: np.array = torch.tensor([0, 0, -9.80665, 0, 0, 0]),
     ) -> None:
         """
         Args:

--- a/src/adam/pytorch/computations.py
+++ b/src/adam/pytorch/computations.py
@@ -20,9 +20,7 @@ class KinDynComputations:
         urdfstring: str,
         joints_name_list: list = None,
         root_link: str = None,
-        gravity: np.array = torch.tensor(
-            [0, 0, -9.80665, 0, 0, 0], dtype=torch.float64
-        ),
+        gravity: np.array = torch.tensor([0, 0, -9.80665, 0, 0, 0]),
     ) -> None:
         """
         Args:

--- a/src/adam/pytorch/torch_like.py
+++ b/src/adam/pytorch/torch_like.py
@@ -17,9 +17,9 @@ class TorchLike(ArrayLike):
     array: torch.Tensor
 
     def __post_init__(self):
-        """Converts array to double precision"""
-        if self.array.dtype != torch.float64:
-            self.array = self.array.double()
+        """Converts array to the default type used in the library"""
+        if self.array.dtype != torch.get_default_dtype():
+            self.array = self.array.to(torch.get_default_dtype())
 
     def __setitem__(self, idx, value: Union["TorchLike", ntp.ArrayLike]) -> "TorchLike":
         """Overrides set item operator"""


### PR DESCRIPTION
This pull request includes changes to the initialization of gravity parameters in two computation files and updates the default tensor type conversion in the `TorchLike` class. The most important changes are:

Initialization of gravity parameters:

* [`src/adam/parametric/pytorch/computations_parametric.py`](diffhunk://#diff-bfca0bc7dfb92ba51b552a3373e9bed6b76e4af02948d8abe8dac203b68d5cc5L26-R26): Simplified the initialization of the `gravity` parameter by removing the explicit `dtype` specification.
* [`src/adam/pytorch/computations.py`](diffhunk://#diff-af8c79f945c2f1f72c9c251ed744891d6a26b2043307c6394d0e8d75d9b79eb4L23-R23): Simplified the initialization of the `gravity` parameter by removing the explicit `dtype` specification.

Default tensor type conversion:

* [`src/adam/pytorch/torch_like.py`](diffhunk://#diff-f3c338b55fb565d9a15edf304d15ee58ab0bc6971d615e78e73b75543af5fb71L20-R22): Updated the `__post_init__` method in the `TorchLike` class to convert arrays to the default tensor type used in the library instead of always converting to double precision.

<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--119.org.readthedocs.build/en/119/

<!-- readthedocs-preview adam-docs end -->