### PR TITLE
Enhance __setitem__ and __getitem__ methods to support Ellipsis indexing in CasadiLike class

### DIFF
--- a/src/adam/casadi/casadi_like.py
+++ b/src/adam/casadi/casadi_like.py
@@ -85,11 +85,27 @@ class CasadiLike(ArrayLike):
 
     def __setitem__(self, idx, value: Union["CasadiLike", npt.ArrayLike]):
         """Overrides set item operator"""
-        self.array[idx] = value.array if type(self) is type(value) else value
+        if idx is Ellipsis:
+            self.array = value.array if isinstance(value, CasadiLike) else value
+        elif isinstance(idx, tuple) and Ellipsis in idx:
+            idx = tuple(slice(None) if i is Ellipsis else i for i in idx)
+            self.array[idx] = value.array if isinstance(value, CasadiLike) else value
+        else:
+            self.array[idx] = value.array if isinstance(value, CasadiLike) else value
+
 
     def __getitem__(self, idx) -> "CasadiLike":
         """Overrides get item operator"""
-        return CasadiLike(self.array[idx])
+        if idx is Ellipsis:
+            # Handle the case where only Ellipsis is passed
+            return CasadiLike(self.array)
+        elif isinstance(idx, tuple) and Ellipsis in idx:
+            # Handle the case where Ellipsis is part of a tuple
+            idx = tuple(slice(None) if k is Ellipsis else k for k in idx)
+            return CasadiLike(self.array[idx])
+        else:
+            # For other cases, delegate to the CasADi object's __getitem__
+            return CasadiLike(self.array[idx])
 
     @property
     def T(self) -> "CasadiLike":

--- a/src/adam/casadi/casadi_like.py
+++ b/src/adam/casadi/casadi_like.py
@@ -93,7 +93,6 @@ class CasadiLike(ArrayLike):
         else:
             self.array[idx] = value.array if isinstance(value, CasadiLike) else value
 
-
     def __getitem__(self, idx) -> "CasadiLike":
         """Overrides get item operator"""
         if idx is Ellipsis:


### PR DESCRIPTION
This pull request includes changes to the `__setitem__` and `__getitem__` methods in the `CasadiLike` class within the `src/adam/casadi/casadi_like.py` file. These changes improve the handling of indices, particularly when using Ellipsis.

Improvements to index handling:

* [`src/adam/casadi/casadi_like.py`](diffhunk://#diff-27f62870a9088500edcb81c3b4fb3830d72ecca8e86e031fa29157b89d517a1dL88-R107): Modified the `__setitem__` method to handle cases where the index is an Ellipsis or a tuple containing an Ellipsis.
* [`src/adam/casadi/casadi_like.py`](diffhunk://#diff-27f62870a9088500edcb81c3b4fb3830d72ecca8e86e031fa29157b89d517a1dL88-R107): Updated the `__getitem__` method to properly handle Ellipsis as an index or part of a tuple index.

<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--120.org.readthedocs.build/en/120/

<!-- readthedocs-preview adam-docs end -->