### PR TITLE
Refactor gravity parameter initialization and update post-init array conversion to use default dtype

### DIFF
--- a/src/adam/parametric/pytorch/computations_parametric.py
+++ b/src/adam/parametric/pytorch/computations_parametric.py
@@ -23,7 +23,8 @@ class KinDynComputationsParametric:
         joints_name_list: list,
         links_name_list: list,
         root_link: str = None,
-        gravity: np.array = torch.tensor([0, 0, -9.80665, 0, 0, 0]) -> None:
+        gravity: np.array = torch.tensor([0, 0, -9.80665, 0, 0, 0])
+    ) -> None:
         """
         Args:
             urdfstring (str): either path or string of the urdf

--- a/src/adam/parametric/pytorch/computations_parametric.py
+++ b/src/adam/parametric/pytorch/computations_parametric.py
@@ -23,10 +23,7 @@ class KinDynComputationsParametric:
         joints_name_list: list,
         links_name_list: list,
         root_link: str = None,
-        gravity: np.array = torch.tensor(
-            [0, 0, -9.80665, 0, 0, 0], dtype=torch.float64
-        ),
-    ) -> None:
+        gravity: np.array = torch.tensor([0, 0, -9.80665, 0, 0, 0]) -> None:
         """
         Args:
             urdfstring (str): either path or string of the urdf

--- a/src/adam/parametric/pytorch/computations_parametric.py
+++ b/src/adam/parametric/pytorch/computations_parametric.py
@@ -33,7 +33,7 @@ class KinDynComputationsParametric:
             root_link (str, optional): Deprecated. The root link is automatically chosen as the link with no parent in the URDF. Defaults to None.
         """
         self.math = SpatialMath()
-        self.g = gravity
+        self.g = gravity.to(torch.get_default_dtype())
         self.links_name_list = links_name_list
         self.joints_name_list = joints_name_list
         self.urdfstring = urdfstring

--- a/src/adam/parametric/pytorch/computations_parametric.py
+++ b/src/adam/parametric/pytorch/computations_parametric.py
@@ -23,7 +23,7 @@ class KinDynComputationsParametric:
         joints_name_list: list,
         links_name_list: list,
         root_link: str = None,
-        gravity: np.array = torch.tensor([0, 0, -9.80665, 0, 0, 0])
+        gravity: np.array = torch.tensor([0, 0, -9.80665, 0, 0, 0]),
     ) -> None:
         """
         Args:

--- a/src/adam/pytorch/computation_batch.py
+++ b/src/adam/pytorch/computation_batch.py
@@ -34,12 +34,18 @@ class KinDynComputationsBatch:
             joints_name_list (list): list of the actuated joints
             root_link (str, optional): Deprecated. The root link is automatically chosen as the link with no parent in the URDF. Defaults to None.
         """
+
+        def to_default_dtype(tensor):
+            """Converts a JAX tensor to the default floating-point type (float32 or float64)."""
+            default_dtype = jnp.array(0.0).dtype  # Get the default floating-point dtype
+            return tensor.astype(default_dtype)
+
         math = SpatialMath()
         factory = URDFModelFactory(path=urdfstring, math=math)
         model = Model.build(factory=factory, joints_name_list=joints_name_list)
         self.rbdalgos = RBDAlgorithms(model=model, math=math)
         self.NDoF = self.rbdalgos.NDoF
-        self.g = gravity
+        self.g = to_default_dtype(gravity)
         self.funcs = {}
         if root_link is not None:
             warnings.warn(

--- a/src/adam/pytorch/computations.py
+++ b/src/adam/pytorch/computations.py
@@ -20,9 +20,7 @@ class KinDynComputations:
         urdfstring: str,
         joints_name_list: list = None,
         root_link: str = None,
-        gravity: np.array = torch.tensor(
-            [0, 0, -9.80665, 0, 0, 0], dtype=torch.float64
-        ),
+        gravity: np.array = torch.tensor([0, 0, -9.80665, 0, 0, 0]),
     ) -> None:
         """
         Args:

--- a/src/adam/pytorch/computations.py
+++ b/src/adam/pytorch/computations.py
@@ -33,7 +33,7 @@ class KinDynComputations:
         model = Model.build(factory=factory, joints_name_list=joints_name_list)
         self.rbdalgos = RBDAlgorithms(model=model, math=math)
         self.NDoF = self.rbdalgos.NDoF
-        self.g = gravity
+        self.g = gravity.to(torch.get_default_dtype())
         if root_link is not None:
             warnings.warn(
                 "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",

--- a/src/adam/pytorch/torch_like.py
+++ b/src/adam/pytorch/torch_like.py
@@ -17,9 +17,10 @@ class TorchLike(ArrayLike):
     array: torch.Tensor
 
     def __post_init__(self):
-        """Converts array to double precision"""
-        if self.array.dtype != torch.float64:
-            self.array = self.array.double()
+        """Converts array to the desired type"""
+        if self.array.dtype != torch.get_default_dtype():
+            self.array = self.array.to(torch.get_default_dtype())
+
 
     def __setitem__(self, idx, value: Union["TorchLike", ntp.ArrayLike]) -> "TorchLike":
         """Overrides set item operator"""

--- a/src/adam/pytorch/torch_like.py
+++ b/src/adam/pytorch/torch_like.py
@@ -21,7 +21,6 @@ class TorchLike(ArrayLike):
         if self.array.dtype != torch.get_default_dtype():
             self.array = self.array.to(torch.get_default_dtype())
 
-
     def __setitem__(self, idx, value: Union["TorchLike", ntp.ArrayLike]) -> "TorchLike":
         """Overrides set item operator"""
         if type(self) is type(value):


### PR DESCRIPTION
This pull request includes several changes to improve the handling of data types and default values in the `adam` package. The most important changes include updates to the initialization methods in two computation files and modifications to the `TorchLike` class to use the default tensor type.

Improvements to initialization methods:

* [`src/adam/parametric/pytorch/computations_parametric.py`](diffhunk://#diff-bfca0bc7dfb92ba51b552a3373e9bed6b76e4af02948d8abe8dac203b68d5cc5L26-R26): Simplified the `gravity` parameter in the `__init__` method by removing the explicit `dtype` specification.
* [`src/adam/pytorch/computations.py`](diffhunk://#diff-af8c79f945c2f1f72c9c251ed744891d6a26b2043307c6394d0e8d75d9b79eb4L23-R23): Simplified the `gravity` parameter in the `__init__` method by removing the explicit `dtype` specification.

Enhancements to `TorchLike` class:

* [`src/adam/pytorch/torch_like.py`](diffhunk://#diff-f3c338b55fb565d9a15edf304d15ee58ab0bc6971d615e78e73b75543af5fb71L20-R23): Modified the `__post_init__` method to convert the array to the default tensor type instead of always converting to double precision.

<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--124.org.readthedocs.build/en/124/

<!-- readthedocs-preview adam-docs end -->