### PR TITLE
Refactor path handling in `get_xml_string` to simplify OS-specific checks

### DIFF
--- a/src/adam/model/std_factories/std_model.py
+++ b/src/adam/model/std_factories/std_model.py
@@ -28,16 +28,10 @@ def get_xml_string(path: str | pathlib.Path):
     isPath = isinstance(path, pathlib.Path)
     isUrdf = False
 
-    # Extract the maximum path length for the current OS
-    try:
-        from ctypes.wintypes import MAX_PATH
-    except ValueError:
-        MAX_PATH = os.pathconf("/", "PC_PATH_MAX")
-
     # Checking if it is a path or an urdf
     if not isPath:
-        if len(path) <= MAX_PATH and "<robot" not in path:
-            path = pathlib.Path(path)
+        if "<robot" not in path:
+            path = pathlib.Path(path).resolve()
             isPath = True
         else:
             root = ET.fromstring(path)


### PR DESCRIPTION
This pull request includes a change to the `get_xml_string` function in the `src/adam/model/std_factories/std_model.py` file. The change simplifies the path length check and ensures that paths are resolved correctly.

Key change:

* Removed the extraction of the maximum path length for the current OS and modified the path check to always resolve the path if it is not an XML string.

<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--125.org.readthedocs.build/en/125/

<!-- readthedocs-preview adam-docs end -->