### PR TITLE
Fix jax version to 0.6.0 in dependencies [TEMPORARY FIX]

### DIFF
--- a/ci_env.yml
+++ b/ci_env.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-repeat
   - icub-models
   - idyntree >=11.0.0
-  - jax==0.6.0
+  - jax<=0.6.0
   - pytorch
   - jax2torch
   - requests

--- a/ci_env.yml
+++ b/ci_env.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-repeat
   - icub-models
   - idyntree >=11.0.0
-  - jax
+  - jax==0.6.0
   - pytorch
   - jax2torch
   - requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ jax = ["jax==0.6.0", "jaxlib"]
 casadi = ["casadi"]
 pytorch = ["torch", "jax", "jaxlib", "jax2torch"]
 test = [
-  "jax==0.6.0"
+  "jax==0.6.0",
   "jaxlib",
   "casadi",
   "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-jax = ["jax==0.6.0", "jaxlib"]
+jax = ["jax<=0.6.0", "jaxlib"]
 casadi = ["casadi"]
 pytorch = ["torch", "jax", "jaxlib", "jax2torch"]
 test = [
-  "jax==0.6.0",
+  "jax<=0.6.0",
   "jaxlib",
   "casadi",
   "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-jax = ["jax", "jaxlib"]
+jax = ["jax==0.6.0", "jaxlib"]
 casadi = ["casadi"]
 pytorch = ["torch", "jax", "jaxlib", "jax2torch"]
 test = [
-  "jax==0.6.0"
+  "jax"
   "jaxlib",
   "casadi",
   "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ jax = ["jax", "jaxlib"]
 casadi = ["casadi"]
 pytorch = ["torch", "jax", "jaxlib", "jax2torch"]
 test = [
-  "jax",
+  "jax==0.6.0"
   "jaxlib",
   "casadi",
   "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ jax = ["jax==0.6.0", "jaxlib"]
 casadi = ["casadi"]
 pytorch = ["torch", "jax", "jaxlib", "jax2torch"]
 test = [
-  "jax"
+  "jax==0.6.0"
   "jaxlib",
   "casadi",
   "torch",

--- a/src/adam/casadi/inverse_kinematics.py
+++ b/src/adam/casadi/inverse_kinematics.py
@@ -582,13 +582,13 @@ class InverseKinematics:
     def add_cost(self, cost: cs.MX):
         """Add a custom cost term to the optimization problem.
 
-        This method appends the provided cost term to the `cost_terms` list. 
-        During the `_finalize_problem` step, all cost terms in this list are 
-        combined using `cs.sum(cs.vertcat(*self.cost_terms))` and minimized 
+        This method appends the provided cost term to the `cost_terms` list.
+        During the `_finalize_problem` step, all cost terms in this list are
+        combined using `cs.sum(cs.vertcat(*self.cost_terms))` and minimized
         as part of the objective function.
 
-        Note: This method ensures that the optimization graph is still modifiable 
-        before adding the cost term. Once the problem is finalized (after the 
+        Note: This method ensures that the optimization graph is still modifiable
+        before adding the cost term. Once the problem is finalized (after the
         first call to `solve()`), no new cost terms can be added.
         Args:
             cost (cs.MX): The cost term to add.


### PR DESCRIPTION
This PR provides a temporary fix for the recent jax update from version 0.6.0 to 0.7.0.
See #132 and #131. 

For now, I'm fixing the JAX version in the dependencies to the last working version. 
I'll fix the general issue hopefully soon.

---

### Copilot summary 

This pull request updates the way the `jax` dependency is specified in both the `ci_env.yml` and `pyproject.toml` files. The main change is to pin the version of `jax` to `0.6.0` instead of allowing any version, which helps ensure consistent environments and reduces the risk of incompatibility issues.

Dependency version pinning:

* Updated the `ci_env.yml` file to specify `jax==0.6.0` instead of an unpinned version for more predictable CI builds.
* Modified the `pyproject.toml` file to pin `jax` to version `0.6.0` in both the `jax` optional dependency group and the `test` dependency group, improving reproducibility for development and testing.

<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--133.org.readthedocs.build/en/133/

<!-- readthedocs-preview adam-docs end -->