### PR TITLE
Fix pypi-ci workflow

### DIFF
--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -55,6 +55,7 @@ jobs:
         path: dist
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
@@ -62,9 +63,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
-    # environment:
-    #   name: testpypi
-    #   url: https://test.pypi.org/p/adam-robotics
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/adam-robotics
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing

--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -84,4 +84,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
-        
+        verbose: true

--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -3,14 +3,11 @@ name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 # Ref: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
 on:
-  workflow_dispatch:
-  push:
-    branches: ["**"]
-    tags-ignore: ["**"]
-  pull_request:
   release:
-    types:
-      - published
+    types: [published]
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   build:
     name: Build distribution 📦
@@ -20,6 +17,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
+        fetch-depth: 0  
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -35,19 +33,17 @@ jobs:
     - name: Store the distribution packages
       uses: actions/upload-artifact@v4
       with:
-        name: python-package-distributions
-        path: dist/
+        name: dist
+        path: dist
 
   publish-to-pypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    needs: build
     if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
-    needs:
-    - build
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/adam-robotics
+    # environment:
+    #   name: pypi
+    #   url: https://pypi.org/p/adam-robotics
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
@@ -55,21 +51,20 @@ jobs:
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
-        name: python-package-distributions
-        path: dist/
+        name: dist
+        path: dist
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs: build
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
-    needs:
-    - build
     runs-on: ubuntu-latest
 
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/adam-robotics
+    # environment:
+    #   name: testpypi
+    #   url: https://test.pypi.org/p/adam-robotics
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
@@ -78,8 +73,8 @@ jobs:
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
-        name: python-package-distributions
-        path: dist/
+        name: dist
+        path: dist
     - name: Publish distribution 📦 to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -85,3 +85,4 @@ jobs:
       with:
         repository-url: https://test.pypi.org/legacy/
         verbose: true
+        skip-existing: true

--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -62,7 +62,7 @@ jobs:
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
     needs: build
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     environment:

--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -18,10 +18,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.x"
     - name: Install pypa/build
       run: >-
         python3 -m
@@ -58,49 +60,6 @@ jobs:
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
-  github-release:
-    name: >-
-      Sign the Python 🐍 distribution 📦 with Sigstore
-      and upload them to GitHub Release
-    needs:
-    - publish-to-pypi
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write  # IMPORTANT: mandatory for making GitHub Releases
-      id-token: write  # IMPORTANT: mandatory for sigstore
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
-      with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
-    - name: Create GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release create
-        '${{ github.ref_name }}'
-        --repo '${{ github.repository }}'
-        --notes ""
-    - name: Upload artifact signatures to GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      # Upload to GitHub Release using the `gh` CLI.
-      # `dist/` contains the built packages, and the
-      # sigstore-produced signatures and certificates.
-      run: >-
-        gh release upload
-        '${{ github.ref_name }}' dist/**
-        --repo '${{ github.repository }}'
-
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
@@ -125,3 +84,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+        

--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -41,9 +41,11 @@ jobs:
     needs: build
     if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    # environment:
-    #   name: pypi
-    #   url: https://pypi.org/p/adam-robotics
+    
+    environment:
+      name: pypi
+      url: https://pypi.org/p/adam-robotics
+      
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
+requires = ["setuptools>=64", "setuptools_scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
-requires = ["wheel", "setuptools>=45", "setuptools_scm[toml]>=6.0"]
 
 [project]
 name = "adam-robotics"
@@ -56,6 +56,9 @@ all = ["jax", "jaxlib", "casadi>=3.6", "torch", "jax2torch"]
 [project.urls]
 "Documentation" = "https://adam-robotics.readthedocs.io/en/latest/"
 "Source" = "https://github.com/ami-iit/adam"
+
+[tool.setuptools_scm]
+local_scheme = "dirty-tag"
 
 [tool.setuptools]
 package-dir = { "" = "src" } # keeps the src/ layout


### PR DESCRIPTION
This pull request updates the Python packaging and publishing workflow, aligning it with https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

### Copilot summary

**CI/CD Workflow Improvements:**

* Simplified and restructured the `.github/workflows/pypi-ci.yml` workflow triggers, ensuring builds run on release, pull request, and workflow dispatch events, and made event types more explicit.
* Refactored job dependencies and artifact naming: standardized the artifact name to `dist`, set explicit job dependencies using `needs`, and improved artifact download/upload steps for consistency across jobs.
* Removed the `github-release` job that signed distributions with Sigstore and uploaded them to GitHub Releases, focusing the workflow solely on PyPI and TestPyPI publishing.

**Build System and Publishing Enhancements:**

* Updated `pyproject.toml` to require newer versions of `setuptools` and `setuptools_scm`, and removed legacy/duplicate requirements, ensuring compatibility with modern Python packaging standards.
* Added `verbose: true` and `skip-existing: true` options to the TestPyPI publishing step, improving feedback and avoiding re-upload errors for existing distributions.

**Configuration Improvements:**

* Added a `[tool.setuptools_scm]` section to `pyproject.toml` to specify `local_scheme = "dirty-tag"`, which controls versioning for local builds.

<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--135.org.readthedocs.build/en/135/

<!-- readthedocs-preview adam-docs end -->