### PR TITLE
Remove repetition of tests in conda win ci

### DIFF
--- a/.github/workflows/conda-forge-tests.yml
+++ b/.github/workflows/conda-forge-tests.yml
@@ -1,4 +1,4 @@
-name: Test ADAM with conda-forge dependencies
+name: Test adam with conda-forge dependencies
 
 on:
   push:
@@ -46,7 +46,7 @@ jobs:
         uname -r
         micromamba list
 
-    - name: Install ADAM
+    - name: Install adam
       shell: bash -l {0}
       run: |
          pip install --no-deps .
@@ -62,5 +62,6 @@ jobs:
       if: contains(matrix.os, 'windows')
       run: |
           # Skip additional dependencies not available on Windows
-          pytest --count=1 -v --ignore-glob=*Jax* --ignore-glob=*pytorch*
+          pytest -v --ignore-glob=*Jax* --ignore-glob=*pytorch*
+
 


### PR DESCRIPTION
This PR removes `--count=100` from
https://github.com/ami-iit/adam/blob/fe457a6f403f6b86e3870553695e0fcc9ec3b584/.github/workflows/conda-forge-tests.yml#L63-L65

For log: this was introduced in https://github.com/ami-iit/adam/pull/41 (after #38). 

### Copilot summary 

* Changed workflow and job step names from "ADAM" to "adam" for consistency with project naming conventions. [[1]](diffhunk://#diff-6e7b748feb065457aefa3c239f7f09d69a894b974e3f8797e833068e7d9560d4L1-R1) [[2]](diffhunk://#diff-6e7b748feb065457aefa3c239f7f09d69a894b974e3f8797e833068e7d9560d4L49-R49)
* Updated the Windows test command to remove the `--count=100` flag from `pytest`, likely to streamline test execution and avoid redundant runs.

<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--136.org.readthedocs.build/en/136/

<!-- readthedocs-preview adam-docs end -->