### PR TITLE
Fix casadi casadi conversion to array after Numpy 2.4 release

### DIFF
--- a/src/adam/model/conversions/idyntree.py
+++ b/src/adam/model/conversions/idyntree.py
@@ -42,8 +42,8 @@ def _to_scalar(x) -> float:
     # Handle CasADi types if available. It should be already a casadi type, but let's be safe
     if isinstance(val, (cs.DM, cs.SX, cs.MX)):
         dm_full = cs.DM(val).full()
-        # Flatten 2D array and extract single scalar
-        val = dm_full[0][0] if isinstance(dm_full, list) else dm_full.flat[0]
+        # `full()` returns a NumPy array; flatten and extract the single scalar
+        val = dm_full.flat[0]
     return float(val)
 
 


### PR DESCRIPTION
This PR fixes the failing action https://github.com/gbionics/adam/actions/runs/20404127584 which fails the test `idyntree_conversion` with 
```bash
/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/adam/model/conversions/idyntree.py:23: in _to_sequence
    val = [float(v) for v in cs.DM(val).full()]
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <iterator object at 0x7f11ce7734c0>

>   val = [float(v) for v in cs.DM(val).full()]
           ^^^^^^^^
E   TypeError: only 0-dimensional arrays can be converted to Python scalars
```

I guess after the release https://numpy.org/news/#numpy-240-released

Indeed there was a deprecation warning before the release:
```
tests/test_idyntree_conversion.py: 6750 warnings
adam/src/adam/model/conversions/idyntree.py:23: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    val = [float(v) for v in cs.DM(val).full()]

tests/test_idyntree_conversion.py: 249 warnings
adam/src/adam/model/conversions/idyntree.py:42: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    return float(val)
```

<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--147.org.readthedocs.build/en/147/

<!-- readthedocs-preview adam-docs end -->