### PR TITLE
Add support to root_link change

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,8 +352,11 @@ kinDyn.set_root_link("chest")
 
 adam re-roots the kinematic tree internally by reversing the joints along the path from the new root to the original URDF root. All dynamics quantities (mass matrix, Jacobians, bias forces, …) are then consistent with the new floating base. Results match iDynTree's `setFloatingBase` API.
 
+> [!IMPORTANT]
+> **Joint serialization is independent of the floating base.** The order of joints in the `joints` vector is fixed by `joints_name_list` at construction time and never changes — only the *base state* inputs (`w_H_b` and base velocity) reflect the new floating base.
+
 > [!NOTE]
-> The `root_link` must be a **link** (not a frame). In URDF models, frames defined as zero-mass fixed-joint children are not valid choices.
+> `root_link` must be a **link** name, not a frame name. Passing a frame name raises a `ValueError` listing valid link names. Frames remain valid as targets for forward kinematics and Jacobians.
 
 ### Inverse Kinematics
 

--- a/README.md
+++ b/README.md
@@ -336,6 +336,25 @@ M = kinDyn.mass_matrix(w_H_b, q)
 com = kinDyn.CoM_position(w_H_b, q)
 ```
 
+### Configurable Floating Base
+
+By default adam uses the root link of the URDF as the floating base. You can choose any other link as the floating base at construction time or at runtime:
+
+```python
+from adam.numpy import KinDynComputations
+
+# Construction-time: use "l_ankle_2" as the floating base
+kinDyn = KinDynComputations(model_path, joints_name_list, root_link="l_ankle_2")
+
+# Runtime setter (rebuilds the kinematic tree)
+kinDyn.set_root_link("chest")
+```
+
+adam re-roots the kinematic tree internally by reversing the joints along the path from the new root to the original URDF root. All dynamics quantities (mass matrix, Jacobians, bias forces, …) are then consistent with the new floating base. Results match iDynTree's `setFloatingBase` API.
+
+> [!NOTE]
+> The `root_link` must be a **link** (not a frame). In URDF models, frames defined as zero-mass fixed-joint children are not valid choices.
+
 ### Inverse Kinematics
 
 ```python
@@ -370,6 +389,7 @@ print("Joint values:\n", q_sol)
 - **Kinematics**: Forward kinematics, Jacobians (frame and base)
 - **Dynamics**: Mass matrix, Coriolis/centrifugal forces and gravity, Articulated body algorithm
 - **Centroidal**: Centroidal momentum matrix and derivatives
+- **Configurable floating base**: Any link can be set as the floating base
 - **Differentiation**: Get gradients, Jacobians, and Hessians automatically
 - **Symbolic**: Build computation graphs with CasADi for optimization
 - **Batched**: Process multiple configurations in parallel with PyTorch

--- a/docs/guides/concepts.rst
+++ b/docs/guides/concepts.rst
@@ -218,3 +218,8 @@ When computing system acceleration with external forces (e.g., contact forces), 
         external_wrenches=external_wrenches
     )
 
+.. seealso::
+
+    :doc:`floating_base` — how to change which link is treated as the
+    floating base.
+

--- a/docs/guides/floating_base.rst
+++ b/docs/guides/floating_base.rst
@@ -1,0 +1,76 @@
+Configurable Floating Base
+==========================
+
+By default adam uses the **root link** of the URDF (the link with no parent) as
+the floating base. You can change this to any other link at construction time or
+at runtime. adam re-roots the kinematic tree internally so that all dynamics
+quantities are consistent with the chosen floating base.
+
+Choosing a root link
+--------------------
+
+Pass ``root_link`` to the constructor:
+
+.. code-block:: python
+
+    from adam.numpy import KinDynComputations
+
+    kinDyn = KinDynComputations(
+        model_path,
+        joints_name_list,
+        root_link="l_ankle_2",   # any link name in the model
+    )
+    kinDyn.set_frame_velocity_representation(adam.Representations.MIXED_REPRESENTATION)
+
+The same parameter is available for all backends (JAX, CasADi, PyTorch):
+
+.. code-block:: python
+
+    from adam.casadi import KinDynComputations as CasADiKinDyn
+    from adam.jax    import KinDynComputations as JAXKinDyn
+    from adam.pytorch import KinDynComputations as TorchKinDyn
+
+    kd_cs    = CasADiKinDyn(model_path, joints_name_list, root_link="chest")
+    kd_jax   = JAXKinDyn(model_path,    joints_name_list, root_link="chest")
+    kd_torch = TorchKinDyn(model_path,  joints_name_list, root_link="chest")
+
+Runtime setter
+--------------
+
+You can also change the floating base after construction. This rebuilds the
+kinematic tree; for CasADi any cached ``cs.Function`` objects must be
+re-requested afterwards.
+
+.. code-block:: python
+
+    kinDyn = KinDynComputations(model_path, joints_name_list)
+    # ... compute some quantities with the default root ...
+
+    kinDyn.set_root_link("chest")
+    # all subsequent calls use "chest" as the floating base
+
+How it works
+------------
+
+When a new root is requested adam finds the path in the kinematic tree from the
+new root to the original URDF root and **reverses** every joint along that path.
+A reversed joint:
+
+- swaps its parent and child links,
+- returns the *inverse* homogeneous transform ``H(q)^{-1}`` in place of the
+  original ``H(q)``,
+- negates and re-expresses the motion subspace so that the Featherstone
+  recursions remain correct.
+
+All joints **not** on the reversal path are unchanged.  The result is
+numerically equivalent to iDynTree's ``setFloatingBase`` API.
+
+.. note::
+
+    ``root_link`` must be a **link** name, not a frame name.  In URDF models,
+    frames are represented as zero-mass fixed-joint children and are not valid
+    floating bases.  Use the parent link of the frame instead.
+
+.. seealso::
+
+    :doc:`concepts` — velocity representations and the floating-base state.

--- a/docs/guides/floating_base.rst
+++ b/docs/guides/floating_base.rst
@@ -71,6 +71,28 @@ numerically equivalent to iDynTree's ``setFloatingBase`` API.
     frames are represented as zero-mass fixed-joint children and are not valid
     floating bases.  Use the parent link of the frame instead.
 
+Joint serialization is independent of the floating base
+--------------------------------------------------------
+
+.. important::
+
+    Changing the root link **does not change the joint position / velocity
+    vector layout**.  The order of joints in ``joints`` (and the matching
+    ``joints_name_list``) is fixed at construction time and stays the same
+    regardless of which link is the floating base.
+
+    The user defines the joint ordering once and it never changes — only the
+    **base state** part of the inputs (``w_H_b`` and the base velocity)
+    reflects the new floating base.
+
+    Concretely, if you construct with::
+
+        kinDyn = KinDynComputations(urdf, ["joint_A", "joint_B"], root_link="l_ankle_2")
+
+    then ``joints[0]`` is always ``joint_A`` and ``joints[1]`` is always
+    ``joint_B``, even though the kinematic tree is now rooted at
+    ``l_ankle_2``.
+
 .. seealso::
 
     :doc:`concepts` — velocity representations and the floating-base state.

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -8,6 +8,7 @@ Detailed guides for understanding and using adam effectively.
 
    concepts
    backend_selection
+   floating_base
    mujoco
    usd
    troubleshooting

--- a/src/adam/casadi/computations.py
+++ b/src/adam/casadi/computations.py
@@ -1,7 +1,5 @@
 # Copyright (C) Istituto Italiano di Tecnologia (IIT). All rights reserved.
 
-import warnings
-
 import casadi as cs
 import numpy as np
 
@@ -28,21 +26,22 @@ class KinDynComputations(KinDynFactoryMixin):
             urdfstring (str): path/string of a URDF or a MuJoCo MjModel.
                 NOTE: The parameter name `urdfstring` is deprecated and will be renamed to `model` in a future release.
             joints_name_list (list): list of the actuated joints
-            root_link (str, optional): Deprecated. The root link is automatically chosen as the link with no parent in the URDF. Defaults to None.
+            root_link (str, optional): the link to use as the floating base.
+                When ``None`` the link with no parent in the URDF is used.
         """
         math = SpatialMath()
         factory = build_model_factory(description=urdfstring, math=math)
-        model = Model.build(factory=factory, joints_name_list=joints_name_list)
+        model = Model.build(
+            factory=factory,
+            joints_name_list=joints_name_list,
+            root_link=root_link,
+        )
         self.rbdalgos = RBDAlgorithms(model=model, math=math)
+        self._factory = factory
+        self._joints_name_list = model.actuated_joints
         self.NDoF = self.rbdalgos.NDoF
         self.g = gravity
         self.f_opts = f_opts
-        if root_link is not None:
-            warnings.warn(
-                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
     def set_frame_velocity_representation(
         self, representation: Representations
@@ -53,6 +52,23 @@ class KinDynComputations(KinDynFactoryMixin):
             representation (Representations): The representation of the velocity
         """
         self.rbdalgos.set_frame_velocity_representation(representation)
+
+    def set_root_link(self, root_link: str) -> None:
+        """Changes the floating base of the robot model.
+
+        Any ``cs.Function`` objects previously obtained from ``*_fun()`` methods
+        are no longer valid and must be recomputed after calling this.
+
+        Args:
+            root_link (str): name of the link to use as the new floating base.
+        """
+        model = Model.build(
+            factory=self._factory,
+            joints_name_list=self._joints_name_list,
+            root_link=root_link,
+        )
+        self.rbdalgos.set_root_link(model)
+        self.NDoF = model.NDoF
 
     def mass_matrix_fun(self) -> cs.Function:
         """Returns the Mass Matrix functions computed the CRBA

--- a/src/adam/core/rbd_algorithms.py
+++ b/src/adam/core/rbd_algorithms.py
@@ -1259,6 +1259,20 @@ class RBDAlgorithms:
                 converted.append(self.math.asarray(arg))
         return converted[0] if len(converted) == 1 else converted
 
+    def set_root_link(self, model: Model) -> None:
+        """Update the robot model to use a different root link.
+
+        Call this *after* rebuilding the model via
+        ``Model.build(factory, joints_name_list, root_link=new_root)``.
+
+        Args:
+            model (Model): pre-built model with the desired root link.
+        """
+        self.model = model
+        self.NDoF = model.NDoF
+        self.root_link = model.tree.root
+        self._prepare_tree_cache()
+
     def _prepare_tree_cache(self) -> None:
         """Pre-compute static tree data so the dynamic algorithms avoid repeated Python work."""
         nodes = list(self.model.tree)
@@ -1294,9 +1308,13 @@ class RBDAlgorithms:
                 self._joint_indices_per_node[idx] = joint.idx
                 if joint.idx is not None:
                     self._joint_index_to_node[int(joint.idx)] = idx
+                # Use parent_arc from the tree so reversed joints are handled correctly.
+                self._joint_by_child[link.name] = joint
 
+        # Add joints whose child is a frame (frames are not tree nodes).
         for joint in self.model.joints.values():
-            self._joint_by_child[joint.child] = joint
+            if joint.child in self.model.frames:
+                self._joint_by_child[joint.child] = joint
 
         self._root_index = self.model.tree.get_idx_from_name(self.root_link)
         self._node_count = node_count

--- a/src/adam/jax/computations.py
+++ b/src/adam/jax/computations.py
@@ -1,7 +1,5 @@
 # Copyright (C) Istituto Italiano di Tecnologia (IIT). All rights reserved.
 
-import warnings
-
 import jax.numpy as jnp
 import numpy as np
 
@@ -29,21 +27,22 @@ class KinDynComputations(KinDynFactoryMixin):
             urdfstring (str): path/string of a URDF or a MuJoCo MjModel.
                 NOTE: The parameter name `urdfstring` is deprecated and will be renamed to `model` in a future release.
             joints_name_list (list): list of the actuated joints
-            root_link (str, optional): Deprecated. The root link is automatically chosen as the link with no parent in the URDF. Defaults to None.
+            root_link (str, optional): the link to use as the floating base.
+                When ``None`` the link with no parent in the URDF is used.
         """
         ref = jnp.array(0.0, dtype=dtype)
         math = SpatialMath(spec_from_reference(ref))
         factory = build_model_factory(description=urdfstring, math=math)
-        model = Model.build(factory=factory, joints_name_list=joints_name_list)
+        model = Model.build(
+            factory=factory,
+            joints_name_list=joints_name_list,
+            root_link=root_link,
+        )
         self.rbdalgos = RBDAlgorithms(model=model, math=math)
+        self._factory = factory
+        self._joints_name_list = model.actuated_joints
         self.NDoF = self.rbdalgos.NDoF
         self.g = jnp.asarray(gravity, dtype=dtype)
-        if root_link is not None:
-            warnings.warn(
-                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
     def set_frame_velocity_representation(
         self, representation: Representations
@@ -54,6 +53,20 @@ class KinDynComputations(KinDynFactoryMixin):
             representation (Representations): The representation of the velocity
         """
         self.rbdalgos.set_frame_velocity_representation(representation)
+
+    def set_root_link(self, root_link: str) -> None:
+        """Changes the floating base of the robot model.
+
+        Args:
+            root_link (str): name of the link to use as the new floating base.
+        """
+        model = Model.build(
+            factory=self._factory,
+            joints_name_list=self._joints_name_list,
+            root_link=root_link,
+        )
+        self.rbdalgos.set_root_link(model)
+        self.NDoF = model.NDoF
 
     def mass_matrix(self, base_transform: jnp.array, joint_positions: jnp.array):
         """Returns the Mass Matrix functions computed the CRBA

--- a/src/adam/model/model.py
+++ b/src/adam/model/model.py
@@ -28,12 +28,18 @@ class Model:
         return len(self.links)
 
     @staticmethod
-    def build(factory: ModelFactory, joints_name_list: list[str] = None) -> "Model":
+    def build(
+        factory: ModelFactory,
+        joints_name_list: list[str] = None,
+        root_link: str = None,
+    ) -> "Model":
         """generates the model starting from the list of joints and the links-joints factory
 
         Args:
             factory (ModelFactory): the factory that generates the links and the joints, starting from a description (eg. urdf)
             joints_name_list (list[str]): the list of the actuated joints
+            root_link (str, optional): the link to use as the floating base. When ``None``
+                the link with no parent in the model description is used.
 
         Returns:
             Model: the model describing the robot
@@ -66,6 +72,9 @@ class Model:
                     joint.idx = idx
 
         tree = Tree.build_tree(links=links_list, joints=joints_list)
+
+        if root_link is not None and root_link != tree.root:
+            tree = tree.reroot(root_link)
 
         # generate some useful dict
         joints: dict[str, Joint] = {joint.name: joint for joint in joints_list}

--- a/src/adam/model/tree.py
+++ b/src/adam/model/tree.py
@@ -198,7 +198,7 @@ class Tree(Iterable):
                 new_nodes[child_node.name].parent = new_nodes[name].link
                 new_nodes[child_node.name].parent_arc = joint
 
-        # Re-wire path edges in reverse direction using _ReversedJoint wrappers.
+        # Re-wire path edges in reverse direction using ReversedJoint wrappers.
         for i in range(len(path) - 1):
             # Original edge: parent=path[i+1], child=path[i]
             orig_joint = self.graph[path[i]].parent_arc

--- a/src/adam/model/tree.py
+++ b/src/adam/model/tree.py
@@ -1,7 +1,56 @@
 import dataclasses
 from typing import Iterable, Iterator, Union
 
+import numpy.typing as npt
+
 from adam.model.abc_factories import Joint, Link
+
+
+class ReversedJoint(Joint):
+    """Reverses the direction of a joint for kinematic-tree re-rooting.
+
+    When re-rooting from ``new_root`` to the original root, each joint on
+    the path needs to carry the child from its *new* parent to its *new*
+    child (which are swapped with respect to the original).
+
+    Mathematical convention (same as in ``RBDAlgorithms``):
+    * ``spatial_transform(q)``  = ``adjoint_inverse(H(q))``
+    * ``homogeneous(q)``        = H(q)   (4x4 homogeneous transform parent→child)
+
+    For the reversed joint (new parent ← original child, new child ← original parent):
+    * ``H_rev(q)``     = ``H_orig(q)⁻¹``
+    * ``X_rev(q)``     = ``adjoint_inverse(H_rev(q))``
+                       = ``adjoint_inverse(H_orig(q)⁻¹)``
+                       = ``adjoint(H_orig(q))``
+    * ``S_rev``        = ``-adjoint(H_orig(0)) @ S_orig``   (constant, pre-computed)
+    """
+
+    def __init__(self, original: Joint) -> None:
+        self.math = original.math
+        self.name = original.name
+        self.parent = original.child  # swapped
+        self.child = original.parent  # swapped
+        self.type = original.type
+        self.axis = original.axis
+        self.origin = original.origin
+        self.limit = original.limit
+        self.idx = original.idx
+        self.original = original
+        # H(0) = H_from_Pos_RPY(origin.xyz, origin.rpy) for all joint types
+        # (revolute/prismatic offset and fixed transform coincide at q=0).
+        H0 = original.math.H_from_Pos_RPY(original.origin.xyz, original.origin.rpy)
+        S_orig = original.motion_subspace()
+        adj_H0 = original.math.adjoint(H0)
+        self._motion_subspace = -original.math.mtimes(adj_H0, S_orig)
+
+    def homogeneous(self, q: npt.ArrayLike) -> npt.ArrayLike:
+        return self.math.homogeneous_inverse(self.original.homogeneous(q))
+
+    def spatial_transform(self, q: npt.ArrayLike) -> npt.ArrayLike:
+        return self.math.adjoint(self.original.homogeneous(q))
+
+    def motion_subspace(self) -> npt.ArrayLike:
+        return self._motion_subspace
 
 
 @dataclasses.dataclass
@@ -72,6 +121,78 @@ class Tree(Iterable):
                 f"Expected only one root, found {len(root_link)}: {root_link}"
             )
         return Tree(nodes, root_link[0])
+
+    def reroot(self, new_root: str) -> "Tree":
+        """Return a new ``Tree`` rooted at ``new_root``.
+
+        Joints on the path from ``new_root`` to the original root are
+        wrapped in :class:`ReversedJoint` so that their parent/child
+        direction, spatial transform, and motion subspace are all consistent
+        with the new root.  All other joints are unchanged.
+
+        Args:
+            new_root (str): name of the link that should become the new root.
+
+        Returns:
+            Tree: a new tree with ``new_root`` as root.
+        """
+        if new_root == self.root:
+            return self
+
+        if new_root not in self.graph:
+            raise ValueError(
+                f"{new_root!r} is not a link in the robot model. "
+                f"Available links: {list(self.graph)}"
+            )
+
+        # Build the path [new_root, ..., old_root] following parent pointers.
+        path: list[str] = []
+        current: str = new_root
+        while True:
+            path.append(current)
+            node = self.graph[current]
+            if node.parent is None:
+                break
+            current = node.parent.name
+
+        # path_set = all link names on the reversal path.
+        path_set: set[str] = set(path)
+
+        # Create fresh (disconnected) nodes for every link.
+        new_nodes: dict[str, Node] = {
+            name: Node(
+                name=name,
+                link=old_node.link,
+                arcs=[],
+                children=[],
+                parent=None,
+                parent_arc=None,
+            )
+            for name, old_node in self.graph.items()
+        }
+
+        # Copy all edges that are NOT on the reversal path.
+        for name, old_node in self.graph.items():
+            for joint, child_node in zip(old_node.arcs, old_node.children):
+                if child_node.name in path_set:
+                    continue  # these edges are re-wired below
+                new_nodes[name].children.append(new_nodes[child_node.name])
+                new_nodes[name].arcs.append(joint)
+                new_nodes[child_node.name].parent = new_nodes[name].link
+                new_nodes[child_node.name].parent_arc = joint
+
+        # Re-wire path edges in reverse direction using _ReversedJoint wrappers.
+        for i in range(len(path) - 1):
+            # Original edge: parent=path[i+1], child=path[i]
+            orig_joint = self.graph[path[i]].parent_arc
+            rev_joint = ReversedJoint(orig_joint)
+            # New edge: parent=path[i], child=path[i+1]
+            new_nodes[path[i]].children.append(new_nodes[path[i + 1]])
+            new_nodes[path[i]].arcs.append(rev_joint)
+            new_nodes[path[i + 1]].parent = new_nodes[path[i]].link
+            new_nodes[path[i + 1]].parent_arc = rev_joint
+
+        return Tree(new_nodes, new_root)
 
     def print(self, root):
         """prints the tree

--- a/src/adam/model/tree.py
+++ b/src/adam/model/tree.py
@@ -135,6 +135,23 @@ class Tree(Iterable):
 
         Returns:
             Tree: a new tree with ``new_root`` as root.
+
+        Example:
+            Given a tree ``A → B → C → D`` (with ``E`` as a child of ``A``
+            and ``F`` as a child of ``D``) and ``A`` as root, rerooting at
+            ``C`` reverses the path ``[C, B, A]`` and leaves subtrees
+            hanging off the path (e.g. ``D``, ``E``, ``F``) unchanged::
+
+                Original (root=A):       Rerooted (root=C):
+                     A                        C
+                    / \\                      / \\
+                   B   E                    D   B    <- reversed joint
+                   |                        |   |
+                   C                        F   A    <- reversed joint
+                   |                            |
+                   D                            E    <- copied as-is
+                   |
+                   F
         """
         if new_root == self.root:
             return self

--- a/src/adam/numpy/computations.py
+++ b/src/adam/numpy/computations.py
@@ -1,7 +1,5 @@
 # Copyright (C) Istituto Italiano di Tecnologia (IIT). All rights reserved.
 
-import warnings
-
 import numpy as np
 
 from adam.core.constants import Representations
@@ -27,21 +25,22 @@ class KinDynComputations(KinDynFactoryMixin):
         Args:
             urdfstring (str): path/string of a URDF or a MuJoCo MjModel
             joints_name_list (list): list of the actuated joints
-            root_link (str, optional): Deprecated. The root link is automatically chosen as the link with no parent in the URDF. Defaults to None.
+            root_link (str, optional): the link to use as the floating base.
+                When ``None`` the link with no parent in the URDF is used.
         """
         ref = np.array(0.0, dtype=dtype)
         math = SpatialMath(spec_from_reference(ref))
         factory = build_model_factory(description=urdfstring, math=math)
-        model = Model.build(factory=factory, joints_name_list=joints_name_list)
+        model = Model.build(
+            factory=factory,
+            joints_name_list=joints_name_list,
+            root_link=root_link,
+        )
         self.rbdalgos = RBDAlgorithms(model=model, math=math)
+        self._factory = factory
+        self._joints_name_list = model.actuated_joints
         self.NDoF = model.NDoF
         self.g = np.asarray(gravity, dtype=dtype)
-        if root_link is not None:
-            warnings.warn(
-                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
     def set_frame_velocity_representation(
         self, representation: Representations
@@ -52,6 +51,20 @@ class KinDynComputations(KinDynFactoryMixin):
             representation (Representations): The representation of the velocity
         """
         self.rbdalgos.set_frame_velocity_representation(representation)
+
+    def set_root_link(self, root_link: str) -> None:
+        """Changes the floating base of the robot model.
+
+        Args:
+            root_link (str): name of the link to use as the new floating base.
+        """
+        model = Model.build(
+            factory=self._factory,
+            joints_name_list=self._joints_name_list,
+            root_link=root_link,
+        )
+        self.rbdalgos.set_root_link(model)
+        self.NDoF = model.NDoF
 
     def mass_matrix(
         self, base_transform: np.ndarray, joint_positions: np.ndarray

--- a/src/adam/pytorch/computations.py
+++ b/src/adam/pytorch/computations.py
@@ -1,8 +1,6 @@
 # Copyright (C) Istituto Italiano di Tecnologia (IIT). All rights reserved.
 
 
-import warnings
-
 import numpy as np
 import torch
 
@@ -33,22 +31,23 @@ class KinDynComputations(KinDynFactoryMixin):
             urdfstring (str): path/string of a URDF or a MuJoCo MjModel.
                 NOTE: The parameter name `urdfstring` is deprecated and will be renamed to `model` in a future release.
             joints_name_list (list): list of the actuated joints
-            root_link (str, optional): Deprecated. The root link is automatically chosen as the link with no parent in the URDF. Defaults to None.
+            root_link (str, optional): the link to use as the floating base.
+                When ``None`` the link with no parent in the URDF is used.
         """
         ref = torch.tensor(0.0, dtype=dtype, device=device)
         spec = spec_from_reference(ref)
         math = SpatialMath(spec=spec)
         factory = build_model_factory(description=urdfstring, math=math)
-        model = Model.build(factory=factory, joints_name_list=joints_name_list)
+        model = Model.build(
+            factory=factory,
+            joints_name_list=joints_name_list,
+            root_link=root_link,
+        )
         self.rbdalgos = RBDAlgorithms(model=model, math=math)
-        self.NDoF = self.rbdalgos.NDoF
+        self._factory = factory
+        self._joints_name_list = model.actuated_joints
+        self.NDoF = model.NDoF
         self.g = gravity.to(dtype=dtype, device=device)
-        if root_link is not None:
-            warnings.warn(
-                "The root_link argument is not used. The root link is automatically chosen as the link with no parent in the URDF",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
     def set_frame_velocity_representation(
         self, representation: Representations
@@ -59,6 +58,20 @@ class KinDynComputations(KinDynFactoryMixin):
             representation (Representations): The representation of the velocity
         """
         self.rbdalgos.set_frame_velocity_representation(representation)
+
+    def set_root_link(self, root_link: str) -> None:
+        """Changes the floating base of the robot model.
+
+        Args:
+            root_link (str): name of the link to use as the new floating base.
+        """
+        model = Model.build(
+            factory=self._factory,
+            joints_name_list=self._joints_name_list,
+            root_link=root_link,
+        )
+        self.rbdalgos.set_root_link(model)
+        self.NDoF = model.NDoF
 
     def mass_matrix(
         self, base_transform: torch.Tensor, joint_positions: torch.Tensor

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ class RobotCfg:
     n_dof: int
     kin_dyn: idyntree.KinDynComputations
     idyn_function_values: IDynFunctionValues
+    root_link: str | None = None
 
 
 VELOCITY_REPRESENTATIONS = [
@@ -61,6 +62,9 @@ ROBOTS = [
     "iCubGenova04",
     "StickBot",
 ]
+
+# l_sole is a frame; l_ankle_2 is the actual link it is attached to.
+ROOT_LINKS = [None, "l_ankle_2"]
 
 
 def get_robot_model_path(robot_name: str) -> str:
@@ -76,13 +80,13 @@ def get_robot_model_path(robot_name: str) -> str:
     return model_path
 
 
-TEST_CONFIGURATIONS = list(product(VELOCITY_REPRESENTATIONS, ROBOTS))
+TEST_CONFIGURATIONS = list(product(VELOCITY_REPRESENTATIONS, ROBOTS, ROOT_LINKS))
 
 
 @pytest.fixture(scope="module", params=TEST_CONFIGURATIONS, ids=str)
 def tests_setup(request) -> RobotCfg | State:
 
-    velocity_representation, robot_name = request.param
+    velocity_representation, robot_name, root_link = request.param
 
     np.random.seed(42)
 
@@ -133,6 +137,9 @@ def tests_setup(request) -> RobotCfg | State:
         raise ValueError(f"Unknown velocity representation: {velocity_representation}")
     kin_dyn.setFrameVelocityRepresentation(idyn_representation)
 
+    if root_link is not None:
+        assert kin_dyn.setFloatingBase(root_link), f"setFloatingBase({root_link!r}) failed"
+
     n_dof = len(joints_name_list)
     # base quantities
     xyz = (np.random.rand(3) - 0.5) * 5
@@ -167,6 +174,7 @@ def tests_setup(request) -> RobotCfg | State:
         n_dof=n_dof,
         kin_dyn=kin_dyn,
         idyn_function_values=idyn_function_values,
+        root_link=root_link,
     )
 
     yield robot_cfg, state

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,7 +138,9 @@ def tests_setup(request) -> RobotCfg | State:
     kin_dyn.setFrameVelocityRepresentation(idyn_representation)
 
     if root_link is not None:
-        assert kin_dyn.setFloatingBase(root_link), f"setFloatingBase({root_link!r}) failed"
+        assert kin_dyn.setFloatingBase(
+            root_link
+        ), f"setFloatingBase({root_link!r}) failed"
 
     n_dof = len(joints_name_list)
     # base quantities

--- a/tests/parametric/test_casadi_parametric.py
+++ b/tests/parametric/test_casadi_parametric.py
@@ -12,6 +12,8 @@ def setup_test(tests_setup) -> KinDynComputationsParametric | RobotCfg | State:
     # skip the tests if the model is not the StickBot
     if robot_cfg.robot_name != "StickBot":
         pytest.skip("Skipping the test because the model is not StickBot")
+    if robot_cfg.root_link is not None:
+        pytest.skip("root link parametrization tested in numpy and casadi only")
     link_name_list = ["chest"]
     adam_kin_dyn = KinDynComputationsParametric(
         robot_cfg.model_path, robot_cfg.joints_name_list, link_name_list

--- a/tests/parametric/test_idyntree_conversion_parametric.py
+++ b/tests/parametric/test_idyntree_conversion_parametric.py
@@ -18,6 +18,8 @@ def setup_test(tests_setup) -> KinDynComputationsParametric | RobotCfg | State:
     # skip the tests if the model is not the StickBot
     if robot_cfg.robot_name != "StickBot":
         pytest.skip("Skipping the test because the model is not StickBot")
+    if robot_cfg.root_link is not None:
+        pytest.skip("root link parametrization tested in numpy and casadi only")
     link_name_list = ["chest"]
     adam_kin_dyn = KinDynComputationsParametric(
         robot_cfg.model_path, robot_cfg.joints_name_list, link_name_list

--- a/tests/parametric/test_jax_parametric.py
+++ b/tests/parametric/test_jax_parametric.py
@@ -11,6 +11,8 @@ def setup_test(tests_setup) -> KinDynComputationsParametric | RobotCfg | State:
     # skip the tests if the model is not the StickBot
     if robot_cfg.robot_name != "StickBot":
         pytest.skip("Skipping the test because the model is not StickBot")
+    if robot_cfg.root_link is not None:
+        pytest.skip("root link parametrization tested in numpy and casadi only")
     link_name_list = ["chest"]
     adam_kin_dyn = KinDynComputationsParametric(
         robot_cfg.model_path, robot_cfg.joints_name_list, link_name_list

--- a/tests/parametric/test_numpy_parametric.py
+++ b/tests/parametric/test_numpy_parametric.py
@@ -11,6 +11,8 @@ def setup_test(tests_setup) -> KinDynComputationsParametric | RobotCfg | State:
     # skip the tests if the model is not the StickBot
     if robot_cfg.robot_name != "StickBot":
         pytest.skip("Skipping the test because the model is not StickBot")
+    if robot_cfg.root_link is not None:
+        pytest.skip("root link parametrization tested in numpy and casadi only")
     link_name_list = ["chest"]
     adam_kin_dyn = KinDynComputationsParametric(
         robot_cfg.model_path, robot_cfg.joints_name_list, link_name_list

--- a/tests/parametric/test_pytorch_parametric.py
+++ b/tests/parametric/test_pytorch_parametric.py
@@ -14,6 +14,8 @@ def setup_test(tests_setup, device) -> KinDynComputationsParametric | RobotCfg |
     # skip the tests if the model is not the StickBot
     if robot_cfg.robot_name != "StickBot":
         pytest.skip("Skipping the test because the model is not StickBot")
+    if robot_cfg.root_link is not None:
+        pytest.skip("root link parametrization tested in numpy and casadi only")
     link_name_list = ["chest"]
     adam_kin_dyn = KinDynComputationsParametric(
         robot_cfg.model_path, robot_cfg.joints_name_list, link_name_list, device=device

--- a/tests/test_casadi.py
+++ b/tests/test_casadi.py
@@ -9,7 +9,11 @@ from adam.casadi import KinDynComputations
 @pytest.fixture(scope="module")
 def setup_test(tests_setup) -> KinDynComputations | RobotCfg | State:
     robot_cfg, state = tests_setup
-    adam_kin_dyn = KinDynComputations(robot_cfg.model_path, robot_cfg.joints_name_list)
+    adam_kin_dyn = KinDynComputations(
+        robot_cfg.model_path,
+        robot_cfg.joints_name_list,
+        root_link=robot_cfg.root_link,
+    )
     adam_kin_dyn.set_frame_velocity_representation(robot_cfg.velocity_representation)
     return adam_kin_dyn, robot_cfg, state
 

--- a/tests/test_idyntree_conversion.py
+++ b/tests/test_idyntree_conversion.py
@@ -10,6 +10,8 @@ from adam.model.conversions.idyntree import to_idyntree_model
 @pytest.fixture(scope="module")
 def setup_test(tests_setup) -> KinDynComputations | RobotCfg | State:
     robot_cfg, state = tests_setup
+    if robot_cfg.root_link is not None:
+        pytest.skip("root link parametrization tested in numpy and casadi only")
     adam_kin_dyn = KinDynComputations(robot_cfg.model_path, robot_cfg.joints_name_list)
     adam_kin_dyn.set_frame_velocity_representation(robot_cfg.velocity_representation)
     robot_cfg.kin_dyn.loadRobotModel(to_idyntree_model(adam_kin_dyn.rbdalgos.model))

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -11,7 +11,12 @@ config.update("jax_enable_x64", True)
 @pytest.fixture(scope="module")
 def setup_test(tests_setup) -> KinDynComputations | RobotCfg | State:
     robot_cfg, state = tests_setup
-    adam_kin_dyn = KinDynComputations(robot_cfg.model_path, robot_cfg.joints_name_list)
+    if robot_cfg.root_link is not None:
+        pytest.skip("root link parametrization tested in numpy and casadi only")
+    adam_kin_dyn = KinDynComputations(
+        robot_cfg.model_path,
+        robot_cfg.joints_name_list, 
+    )
     adam_kin_dyn.set_frame_velocity_representation(robot_cfg.velocity_representation)
     return adam_kin_dyn, robot_cfg, state
 

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -15,7 +15,7 @@ def setup_test(tests_setup) -> KinDynComputations | RobotCfg | State:
         pytest.skip("root link parametrization tested in numpy and casadi only")
     adam_kin_dyn = KinDynComputations(
         robot_cfg.model_path,
-        robot_cfg.joints_name_list, 
+        robot_cfg.joints_name_list,
     )
     adam_kin_dyn.set_frame_velocity_representation(robot_cfg.velocity_representation)
     return adam_kin_dyn, robot_cfg, state

--- a/tests/test_jax_batch.py
+++ b/tests/test_jax_batch.py
@@ -377,7 +377,9 @@ def test_jacobian_dot(setup_test):
         vels = jnp.concatenate([base_vel, joints_vel], axis=1)
         return (jac_dot @ vels[..., jnp.newaxis]).squeeze(-1).sum()
 
-    # Skip gradient/variation checks when target frame is fixed to root (constant output)
+    # Note: when root_link == target frame, the output is constant and
+    # gradient/variation checks would fail.  This test skips non-default
+    # root_link configurations (see setup_test fixture).
     grad_fn = grad(jacobian_dot_nu_sum, argnums=(0, 1, 2, 3))
     try:
         grad_results = grad_fn(

--- a/tests/test_jax_batch.py
+++ b/tests/test_jax_batch.py
@@ -13,8 +13,12 @@ config.update("jax_enable_x64", True)
 @pytest.fixture(scope="module")
 def setup_test(tests_setup) -> tuple[KinDynComputations, RobotCfg, State, int]:
     robot_cfg, state = tests_setup
-
-    adam_kin_dyn = KinDynComputations(robot_cfg.model_path, robot_cfg.joints_name_list)
+    if robot_cfg.root_link is not None:
+        pytest.skip("root link parametrization tested in numpy and casadi only")
+    adam_kin_dyn = KinDynComputations(
+        robot_cfg.model_path,
+        robot_cfg.joints_name_list,
+    )
     adam_kin_dyn.set_frame_velocity_representation(robot_cfg.velocity_representation)
 
     # Create a smaller batch for validation tests
@@ -373,6 +377,7 @@ def test_jacobian_dot(setup_test):
         vels = jnp.concatenate([base_vel, joints_vel], axis=1)
         return (jac_dot @ vels[..., jnp.newaxis]).squeeze(-1).sum()
 
+    # Skip gradient/variation checks when target frame is fixed to root (constant output)
     grad_fn = grad(jacobian_dot_nu_sum, argnums=(0, 1, 2, 3))
     try:
         grad_results = grad_fn(

--- a/tests/test_jax_batch.py
+++ b/tests/test_jax_batch.py
@@ -377,9 +377,6 @@ def test_jacobian_dot(setup_test):
         vels = jnp.concatenate([base_vel, joints_vel], axis=1)
         return (jac_dot @ vels[..., jnp.newaxis]).squeeze(-1).sum()
 
-    # Note: when root_link == target frame, the output is constant and
-    # gradient/variation checks would fail.  This test skips non-default
-    # root_link configurations (see setup_test fixture).
     grad_fn = grad(jacobian_dot_nu_sum, argnums=(0, 1, 2, 3))
     try:
         grad_results = grad_fn(

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -8,7 +8,11 @@ from adam.numpy import KinDynComputations
 @pytest.fixture(scope="module")
 def setup_test(tests_setup) -> KinDynComputations | RobotCfg | State:
     robot_cfg, state = tests_setup
-    adam_kin_dyn = KinDynComputations(robot_cfg.model_path, robot_cfg.joints_name_list)
+    adam_kin_dyn = KinDynComputations(
+        robot_cfg.model_path,
+        robot_cfg.joints_name_list,
+        root_link=robot_cfg.root_link,
+    )
     adam_kin_dyn.set_frame_velocity_representation(robot_cfg.velocity_representation)
     return adam_kin_dyn, robot_cfg, state
 

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -9,6 +9,8 @@ from adam.pytorch import KinDynComputations
 @pytest.fixture(scope="module")
 def setup_test(tests_setup, device) -> KinDynComputations | RobotCfg | State:
     robot_cfg, state = tests_setup
+    if robot_cfg.root_link is not None:
+        pytest.skip("root link parametrization tested in numpy and casadi only")
     adam_kin_dyn = KinDynComputations(
         robot_cfg.model_path,
         robot_cfg.joints_name_list,

--- a/tests/test_pytorch_batch.py
+++ b/tests/test_pytorch_batch.py
@@ -10,7 +10,8 @@ from adam.pytorch import KinDynComputationsBatch
 @pytest.fixture(scope="module")
 def setup_test(tests_setup, device) -> KinDynComputationsBatch | RobotCfg | State:
     robot_cfg, state = tests_setup
-
+    if robot_cfg.root_link is not None:
+        pytest.skip("root link parametrization tested in numpy and casadi only")
     adam_kin_dyn = KinDynComputationsBatch(
         robot_cfg.model_path,
         robot_cfg.joints_name_list,

--- a/tests/test_usd.py
+++ b/tests/test_usd.py
@@ -12,6 +12,8 @@ from adam.numpy.numpy_like import SpatialMath
 @pytest.fixture(scope="module")
 def setup_test(tests_setup, tmp_path_factory) -> KinDynComputations | RobotCfg | State:
     robot_cfg, state = tests_setup
+    if robot_cfg.root_link is not None:
+        pytest.skip("root link parametrization tested in numpy and casadi only")
 
     out_dir = tmp_path_factory.mktemp("newton_usd")
 

--- a/tests/test_usd_conversion.py
+++ b/tests/test_usd_conversion.py
@@ -12,6 +12,8 @@ def setup_test(
     tests_setup, tmp_path_factory
 ) -> tuple[KinDynComputations, KinDynComputations, RobotCfg, State]:
     robot_cfg, state = tests_setup
+    if robot_cfg.root_link is not None:
+        pytest.skip("root link parametrization tested in numpy and casadi only")
 
     out_dir = tmp_path_factory.mktemp(f"usd_{robot_cfg.robot_name}")
     usd_path = out_dir / f"{robot_cfg.robot_name}.usda"


### PR DESCRIPTION
This pull request introduces support for a configurable floating base, allowing users to select any link in the robot model as the floating base both at construction time and at runtime. 
This is achieved by internally re-rooting the kinematic tree, ensuring that all dynamics computations remain consistent with the new base. Tests are done as usual against iDynTree.

--- 

**Configurable Floating Base Support**

* Added the ability to specify `root_link` in the `KinDynComputations` constructors for all backends, enabling any link to be set as the floating base at construction time. [[1]](diffhunk://#diff-3f29e7ed745f711544e5c2858ac52f7dd6f6719cadc86bf4e3bf3b66dbd82486L31-R42) [[2]](diffhunk://#diff-3f29e7ed745f711544e5c2858ac52f7dd6f6719cadc86bf4e3bf3b66dbd82486R76-R78) [[3]](diffhunk://#diff-5c27f7e5ef1fd8abe062c66af95615787081125a90ef3e5f166f1334bd7cffb9L31-L45) [[4]](diffhunk://#diff-e75e3bc3375374ec63d2a170a05d8c9807fe9290c98b2df4db5e1c80757fecbfL32-L46)
* Introduced a `set_root_link` method in `KinDynComputations` classes (NumPy, JAX, CasADi) to allow changing the floating base at runtime, which rebuilds the kinematic tree and updates internal state accordingly. [[1]](diffhunk://#diff-5c27f7e5ef1fd8abe062c66af95615787081125a90ef3e5f166f1334bd7cffb9R56-R72) [[2]](diffhunk://#diff-e75e3bc3375374ec63d2a170a05d8c9807fe9290c98b2df4db5e1c80757fecbfR57-R70) [[3]](diffhunk://#diff-325c3685bad0e866c0636270700b9cd8fb6e29265b3bc92dada7fc6afe49516aR1262-R1275)

**Kinematic Tree and Model Enhancements**

* Implemented the `Tree.reroot` method and the `ReversedJoint` class to re-root the kinematic tree, reversing the direction and transforms of joints along the path from the new root to the original root. This ensures correct kinematics and dynamics for the new floating base. [[1]](diffhunk://#diff-cd292ec7cc52999808fde06d56015d82e93c78825604fa6e77812814b657d749R4-R55) [[2]](diffhunk://#diff-cd292ec7cc52999808fde06d56015d82e93c78825604fa6e77812814b657d749R125-R213)
* Updated model and RBD algorithms to support dynamic re-rooting and to ensure all caches and mappings are consistent with the new tree structure.

**Documentation Updates**

* Added a new detailed guide `floating_base.rst` explaining how to use configurable floating bases, including examples and backend support. Linked this guide from the main documentation index and from relevant conceptual guides. [[1]](diffhunk://#diff-6eeb78a1b1e257d0ea585f52c58ef2309f85508af67794c74c025575d90d1c1fR1-R76) [[2]](diffhunk://#diff-11e75d22a48056ab2eb560931c13f58a4033afeaaffd5a6a58c750203b8bb0c9R11) [[3]](diffhunk://#diff-969a7b47b249c2fd492bc2f373fee071bfcb43f6f0a2751f67130daed10a0d4dR221-R225)
* Updated the README to document the new floating base feature and provide usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R339-R357) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R392)


<!-- readthedocs-preview adam-docs start -->
----
📚 Documentation preview 📚: https://adam-docs--160.org.readthedocs.build/en/160/

<!-- readthedocs-preview adam-docs end -->